### PR TITLE
correct reading bitfields with sizes between 32bit and 64bit

### DIFF
--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -296,7 +296,8 @@ uint64_t kaitai::kstream::read_bits_int(int n) {
     }
 
     // raw mask with required number of 1s, starting from lowest bit
-    uint64_t mask = (1 << n) - 1;
+    uint64_t mask = ((uint64_t)1 << n) - 1;
+    if (n==64) {mask = 0xFFFFFFFFFFFFFFFF;}
     // shift mask to align with highest bits available in @bits
     int shift_bits = m_bits_left - n;
     mask <<= shift_bits;
@@ -304,7 +305,8 @@ uint64_t kaitai::kstream::read_bits_int(int n) {
     uint64_t res = (m_bits & mask) >> shift_bits;
     // clear top bits that we've just read => AND with 1s
     m_bits_left -= n;
-    mask = (1 << m_bits_left) - 1;
+    if (m_bits_left==64) {mask = 0xFFFFFFFFFFFFFFFF;}
+    else {mask = ((uint64_t)1 << m_bits_left) - 1;}
     m_bits &= mask;
 
     return res;


### PR DESCRIPTION
The line
uint64_t mask = (1 << n) -1;
might lead to unexpected results. "1" might be of type (signed) integer. An integer might have 32 bits or less. (1 << n) will have the same datatype as "1". This causes unintended behavior for n >= 32.

let type that is left-shiftet to generate a bitmask be of type uint64_t so that bitfields with length 32 to 63 are read properly; add special case for 64 bitfield case; more than 64 bits are not supported at the moment