### PR TITLE
Add build support for macOS, which is missing byteswap.h

### DIFF
--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -1,7 +1,18 @@
 #include <kaitai/kaitaistream.h>
 
+#if defined(__APPLE__)
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+#define __BYTE_ORDER    BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#else // !__APPLE__
 #include <endian.h>
 #include <byteswap.h>
+#endif
 
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
byteswap.h is an unportable GNU extension and it is missing on macOS. This commit provides a compatibility layer which relies on the `OSSwapInt*` macros defined in `<libkern/OSByteOrder.h>`.  

This commit defines the required information inline in `kaitaistream.cpp`: if preferable, it might be implemented in a separate header (e.g. `portable_byteswap.h`).

(Relevant issue: https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/issues/10)