### PR TITLE
VC++ support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,18 @@ cmake_minimum_required (VERSION 3.3)
 
 set (CMAKE_INCLUDE_CURRENT_DIR ON)
 
+find_package(ZLIB)
+
+find_path(ICONV_INCLUDE_DIRS iconv.h)
+mark_as_advanced(ICONV_INCLUDE_DIRS)
+find_library(ICONV_LIBRARIES NAMES libiconv libiconv-2 c)
+mark_as_advanced(ICONV_LIBRARIES)
+
+set(ICONV_FOUND FALSE)
+if(ICONV_INCLUDE_DIRS AND ICONV_LIBRARIES)
+    SET(ICONV_FOUND TRUE)
+endif()
+
 set (HEADERS
     kaitai/kaitaistream.h
     kaitai/kaitaistruct.h
@@ -14,10 +26,23 @@ set (SOURCES
 
 add_library (${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
 
-if (APPLE)
-	TARGET_LINK_LIBRARIES(${PROJECT_NAME} z iconv)
+if (ZLIB_FOUND)
+    target_include_directories(${PROJECT_NAME} PRIVATE ${ZLIB_INCLUDE_DIRS})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${ZLIB_LIBRARIES})
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_ZLIB)
 endif()
 
-install (TARGETS ${PROJECT_NAME}
-    LIBRARY DESTINATION lib
-)
+if(ICONV_FOUND)
+    target_include_directories(${PROJECT_NAME} PRIVATE ${ICONV_INCLUDE_DIRS})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${ICONV_LIBRARIES})
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_ICONV)
+endif()
+
+if (WIN32)
+    install(TARGETS ${PROJECT_NAME}
+        RUNTIME DESTINATION lib)
+else()
+    install (TARGETS ${PROJECT_NAME}
+        LIBRARY DESTINATION lib
+    )
+endif()

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -9,7 +9,15 @@
 #define __BYTE_ORDER    BYTE_ORDER
 #define __BIG_ENDIAN    BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
-#else // !__APPLE__
+#elif defined(_MSC_VER) // !__APPLE__
+#include <stdlib.h>
+#define __LITTLE_ENDIAN     1234
+#define __BIG_ENDIAN        4321
+#define __BYTE_ORDER        __LITTLE_ENDIAN
+#define bswap_16(x) _byteswap_ushort(x)
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
+#else // !__APPLE__ or !_MSC_VER
 #include <endian.h>
 #include <byteswap.h>
 #endif
@@ -333,7 +341,7 @@ uint64_t kaitai::kstream::get_mask_ones(int n) {
 // Byte arrays
 // ========================================================================
 
-std::string kaitai::kstream::read_bytes(ssize_t len) {
+std::string kaitai::kstream::read_bytes(std::streamsize len) {
     std::vector<char> result(len);
     m_io->read(&result[0], len);
     return std::string(result.begin(), result.end());
@@ -450,8 +458,6 @@ std::string kaitai::kstream::process_rotate_left(std::string data, int amount) {
     return result;
 }
 
-#define KS_ZLIB
-
 #ifdef KS_ZLIB
 #include <zlib.h>
 
@@ -540,8 +546,6 @@ std::string kaitai::kstream::reverse(std::string val) {
 // Other internal methods
 // ========================================================================
 
-#define KS_STR_ENCODING_ICONV
-
 #ifndef KS_STR_DEFAULT_ENCODING
 #define KS_STR_DEFAULT_ENCODING "UTF-8"
 #endif
@@ -606,7 +610,7 @@ std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) 
     return dst;
 }
 #else
-std::string kaitai::kstream::bytes_to_str(std::string src, const char *src_enc) {
+std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) {
     return src;
 }
 #endif

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -155,7 +155,7 @@ public:
     /** @name Byte arrays */
     //@{
 
-    std::string read_bytes(ssize_t len);
+    std::string read_bytes(std::streamsize len);
     std::string read_bytes_full();
     std::string read_bytes_term(char term, bool include, bool consume, bool eos_error);
     std::string ensure_fixed_contents(std::string expected);


### PR DESCRIPTION
I added support for Visual C++.

Also moved zlib & iconv support to CMakeList and make them optional.

For Visual C++ 2015 update 3 and 2017 we can install zlib & iconv using [vcpkg](https://github.com/Microsoft/vcpkg)

```
vcpkg install zlib libiconv
cmake -DCMAKE_TOOLCHAIN_FILE=<vcpkg_root>/scripts/buildsystems/vcpkg.cmake .
```
Issues: kaitai-io/kaitai_struct#124 #11