### PR TITLE
Code improvment

### DIFF
--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -421,22 +421,22 @@ std::string kaitai::kstream::bytes_terminate(std::string src, char term, bool in
 // ========================================================================
 
 std::string kaitai::kstream::process_xor_one(std::string data, uint8_t key) {
-    int len = data.length();
+    size_t len = data.length();
     std::string result(len, ' ');
 
-    for (int i = 0; i < len; i++)
+    for (size_t i = 0; i < len; i++)
         result[i] = data[i] ^ key;
 
     return result;
 }
 
 std::string kaitai::kstream::process_xor_many(std::string data, std::string key) {
-    int len = data.length();
-    int kl = key.length();
+    size_t len = data.length();
+    size_t kl = key.length();
     std::string result(len, ' ');
 
-    int ki = 0;
-    for (int i = 0; i < len; i++) {
+    size_t ki = 0;
+    for (size_t i = 0; i < len; i++) {
         result[i] = data[i] ^ key[ki];
         ki++;
         if (ki >= kl)
@@ -447,10 +447,10 @@ std::string kaitai::kstream::process_xor_many(std::string data, std::string key)
 }
 
 std::string kaitai::kstream::process_rotate_left(std::string data, int amount) {
-    int len = data.length();
+    size_t len = data.length();
     std::string result(len, ' ');
 
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         uint8_t bits = data[i];
         result[i] = (bits << amount) | (bits >> (8 - amount));
     }

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -386,7 +386,7 @@ std::string kaitai::kstream::read_bytes_term(char term, bool include, bool consu
     return result;
 }
 
-std::string kaitai::kstream::ensure_fixed_contents(const std::string& expected) {
+std::string kaitai::kstream::ensure_fixed_contents(std::string expected) {
     std::string actual = read_bytes(expected.length());
 
     if (actual != expected) {
@@ -398,7 +398,7 @@ std::string kaitai::kstream::ensure_fixed_contents(const std::string& expected) 
     return actual;
 }
 
-std::string kaitai::kstream::bytes_strip_right(const std::string& src, char pad_byte) {
+std::string kaitai::kstream::bytes_strip_right(std::string src, char pad_byte) {
     std::size_t new_len = src.length();
 
     while (new_len > 0 && src[new_len - 1] == pad_byte)
@@ -407,7 +407,7 @@ std::string kaitai::kstream::bytes_strip_right(const std::string& src, char pad_
     return src.substr(0, new_len);
 }
 
-std::string kaitai::kstream::bytes_terminate(const std::string& src, char term, bool include) {
+std::string kaitai::kstream::bytes_terminate(std::string src, char term, bool include) {
     std::size_t new_len = 0;
     std::size_t max_len = src.length();
 
@@ -424,7 +424,7 @@ std::string kaitai::kstream::bytes_terminate(const std::string& src, char term, 
 // Byte array processing
 // ========================================================================
 
-std::string kaitai::kstream::process_xor_one(const std::string& data, uint8_t key) {
+std::string kaitai::kstream::process_xor_one(std::string data, uint8_t key) {
     size_t len = data.length();
     std::string result(len, ' ');
 
@@ -434,7 +434,7 @@ std::string kaitai::kstream::process_xor_one(const std::string& data, uint8_t ke
     return result;
 }
 
-std::string kaitai::kstream::process_xor_many(const std::string& data, const std::string& key) {
+std::string kaitai::kstream::process_xor_many(std::string data, std::string key) {
     size_t len = data.length();
     size_t kl = key.length();
     std::string result(len, ' ');
@@ -450,7 +450,7 @@ std::string kaitai::kstream::process_xor_many(const std::string& data, const std
     return result;
 }
 
-std::string kaitai::kstream::process_rotate_left(const std::string& data, int amount) {
+std::string kaitai::kstream::process_rotate_left(std::string data, int amount) {
     size_t len = data.length();
     std::string result(len, ' ');
 
@@ -560,7 +560,7 @@ std::string kaitai::kstream::reverse(std::string val) {
 #include <cerrno>
 #include <stdexcept>
 
-std::string kaitai::kstream::bytes_to_str(std::string src, const std::string& src_enc) {
+std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) {
     iconv_t cd = iconv_open(KS_STR_DEFAULT_ENCODING, src_enc.c_str());
 
     if (cd == (iconv_t) -1) {
@@ -614,7 +614,7 @@ std::string kaitai::kstream::bytes_to_str(std::string src, const std::string& sr
     return dst;
 }
 #elif defined(KS_STR_ENCODING_NONE)
-std::string kaitai::kstream::bytes_to_str(std::string src, const std::string& src_enc) {
+std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) {
     return src;
 }
 #else

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -343,7 +343,11 @@ uint64_t kaitai::kstream::get_mask_ones(int n) {
 
 std::string kaitai::kstream::read_bytes(std::streamsize len) {
     std::vector<char> result(len);
-    m_io->read(&result[0], len);
+
+    if (len > 0 ) {
+        m_io->read(&result[0], len);
+    }
+
     return std::string(result.begin(), result.end());
 }
 

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -382,7 +382,7 @@ std::string kaitai::kstream::read_bytes_term(char term, bool include, bool consu
     return result;
 }
 
-std::string kaitai::kstream::ensure_fixed_contents(std::string expected) {
+std::string kaitai::kstream::ensure_fixed_contents(const std::string& expected) {
     std::string actual = read_bytes(expected.length());
 
     if (actual != expected) {
@@ -394,7 +394,7 @@ std::string kaitai::kstream::ensure_fixed_contents(std::string expected) {
     return actual;
 }
 
-std::string kaitai::kstream::bytes_strip_right(std::string src, char pad_byte) {
+std::string kaitai::kstream::bytes_strip_right(const std::string& src, char pad_byte) {
     std::size_t new_len = src.length();
 
     while (new_len > 0 && src[new_len - 1] == pad_byte)
@@ -403,7 +403,7 @@ std::string kaitai::kstream::bytes_strip_right(std::string src, char pad_byte) {
     return src.substr(0, new_len);
 }
 
-std::string kaitai::kstream::bytes_terminate(std::string src, char term, bool include) {
+std::string kaitai::kstream::bytes_terminate(const std::string& src, char term, bool include) {
     std::size_t new_len = 0;
     std::size_t max_len = src.length();
 
@@ -420,7 +420,7 @@ std::string kaitai::kstream::bytes_terminate(std::string src, char term, bool in
 // Byte array processing
 // ========================================================================
 
-std::string kaitai::kstream::process_xor_one(std::string data, uint8_t key) {
+std::string kaitai::kstream::process_xor_one(const std::string& data, uint8_t key) {
     size_t len = data.length();
     std::string result(len, ' ');
 
@@ -430,7 +430,7 @@ std::string kaitai::kstream::process_xor_one(std::string data, uint8_t key) {
     return result;
 }
 
-std::string kaitai::kstream::process_xor_many(std::string data, std::string key) {
+std::string kaitai::kstream::process_xor_many(const std::string& data, const std::string& key) {
     size_t len = data.length();
     size_t kl = key.length();
     std::string result(len, ' ');
@@ -446,7 +446,7 @@ std::string kaitai::kstream::process_xor_many(std::string data, std::string key)
     return result;
 }
 
-std::string kaitai::kstream::process_rotate_left(std::string data, int amount) {
+std::string kaitai::kstream::process_rotate_left(const std::string& data, int amount) {
     size_t len = data.length();
     std::string result(len, ' ');
 
@@ -556,7 +556,7 @@ std::string kaitai::kstream::reverse(std::string val) {
 #include <cerrno>
 #include <stdexcept>
 
-std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) {
+std::string kaitai::kstream::bytes_to_str(std::string src, const std::string& src_enc) {
     iconv_t cd = iconv_open(KS_STR_DEFAULT_ENCODING, src_enc.c_str());
 
     if (cd == (iconv_t) -1) {
@@ -610,7 +610,7 @@ std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) 
     return dst;
 }
 #elif defined(KS_STR_ENCODING_NONE)
-std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) {
+std::string kaitai::kstream::bytes_to_str(std::string src, const std::string& src_enc) {
     return src;
 }
 #else

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -158,11 +158,11 @@ public:
     std::string read_bytes(std::streamsize len);
     std::string read_bytes_full();
     std::string read_bytes_term(char term, bool include, bool consume, bool eos_error);
-    std::string ensure_fixed_contents(std::string expected);
+    std::string ensure_fixed_contents(const std::string& expected);
 
-    static std::string bytes_strip_right(std::string src, char pad_byte);
-    static std::string bytes_terminate(std::string src, char term, bool include);
-    static std::string bytes_to_str(std::string src, std::string src_enc);
+    static std::string bytes_strip_right(const std::string& src, char pad_byte);
+    static std::string bytes_terminate(const std::string& src, char term, bool include);
+    static std::string bytes_to_str(std::string src, const std::string& src_enc);
 
     //@}
 
@@ -176,7 +176,7 @@ public:
      * @param key value to XOR with
      * @return processed data
      */
-    static std::string process_xor_one(std::string data, uint8_t key);
+    static std::string process_xor_one(const std::string& data, uint8_t key);
 
     /**
      * Performs a XOR processing with given data, XORing every byte of input with a key
@@ -186,7 +186,7 @@ public:
      * @param key array of bytes to XOR with
      * @return processed data
      */
-    static std::string process_xor_many(std::string data, std::string key);
+    static std::string process_xor_many(const std::string& data, const std::string& key);
 
     /**
      * Performs a circular left rotation shift for a given buffer by a given amount of bits,
@@ -196,7 +196,7 @@ public:
      * @param amount number of bits to shift by
      * @return copy of source array with requested shift applied
      */
-    static std::string process_rotate_left(std::string data, int amount);
+    static std::string process_rotate_left(const std::string& data, int amount);
 
 #ifdef KS_ZLIB
     /**

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -158,11 +158,11 @@ public:
     std::string read_bytes(std::streamsize len);
     std::string read_bytes_full();
     std::string read_bytes_term(char term, bool include, bool consume, bool eos_error);
-    std::string ensure_fixed_contents(const std::string& expected);
+    std::string ensure_fixed_contents(std::string expected);
 
-    static std::string bytes_strip_right(const std::string& src, char pad_byte);
-    static std::string bytes_terminate(const std::string& src, char term, bool include);
-    static std::string bytes_to_str(std::string src, const std::string& src_enc);
+    static std::string bytes_strip_right(std::string src, char pad_byte);
+    static std::string bytes_terminate(std::string src, char term, bool include);
+    static std::string bytes_to_str(std::string src, std::string src_enc);
 
     //@}
 
@@ -176,7 +176,7 @@ public:
      * @param key value to XOR with
      * @return processed data
      */
-    static std::string process_xor_one(const std::string& data, uint8_t key);
+    static std::string process_xor_one(std::string data, uint8_t key);
 
     /**
      * Performs a XOR processing with given data, XORing every byte of input with a key
@@ -186,7 +186,7 @@ public:
      * @param key array of bytes to XOR with
      * @return processed data
      */
-    static std::string process_xor_many(const std::string& data, const std::string& key);
+    static std::string process_xor_many(std::string data, std::string key);
 
     /**
      * Performs a circular left rotation shift for a given buffer by a given amount of bits,
@@ -196,7 +196,7 @@ public:
      * @param amount number of bits to shift by
      * @return copy of source array with requested shift applied
      */
-    static std::string process_rotate_left(const std::string& data, int amount);
+    static std::string process_rotate_left(std::string data, int amount);
 
 #ifdef KS_ZLIB
     /**

--- a/kaitai/kaitaistruct.h
+++ b/kaitai/kaitaistruct.h
@@ -7,12 +7,12 @@ namespace kaitai {
 
 class kstruct {
 public:
-    kstruct(kstream *_io) { m__io = _io; };
-    virtual ~kstruct() {};
+    kstruct(kstream *_io) { m__io = _io; }
+    virtual ~kstruct() {}
 protected:
     kstream *m__io;
 public:
-    kstream *_io() { return m__io; };
+    kstream *_io() { return m__io; }
 };
 
 }


### PR DESCRIPTION
Summary:
1. Fix warnings
2. Pass string as reference
3. Fix crashing when we try to read this structure if readed string size == 0

```yaml
  string:
    seq:
      - id: size
        type: u2
      - id: desc
        type: str
        size: size
```