### PR TITLE
Added CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ set (SOURCES
     kaitai/kaitaistream.cpp
 )
 
+option(USE_STRING_ENCODING "Decode strings via iconv" ON)
+
 add_library (${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
 
 if (ZLIB_FOUND)
@@ -35,7 +37,14 @@ endif()
 if(ICONV_FOUND)
     target_include_directories(${PROJECT_NAME} PRIVATE ${ICONV_INCLUDE_DIRS})
     target_link_libraries(${PROJECT_NAME} PRIVATE ${ICONV_LIBRARIES})
+endif()
+
+if (ICONV_FOUND AND USE_STRING_ENCODING)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_ICONV)
+elseif (NOT USE_STRING_ENCODING)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_NONE)
+else()
+    # User action requested
 endif()
 
 if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set (SOURCES
     kaitai/kaitaistream.cpp
 )
 
-option(USE_STRING_ENCODING "Decode strings via iconv" ON)
+set(STRING_ENCODING_TYPE "ICONV" CACHE STRING "Set the way strings have to be encoded (ICONV|NONE|...)")
 
 add_library (${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
 
@@ -39,9 +39,9 @@ if(ICONV_FOUND)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${ICONV_LIBRARIES})
 endif()
 
-if (ICONV_FOUND AND USE_STRING_ENCODING)
+if (STRING_ENCODING_TYPE STREQUAL "ICONV")
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_ICONV)
-elseif (NOT USE_STRING_ENCODING)
+elseif (STRING_ENCODING_TYPE STREQUAL "NONE")
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_NONE)
 else()
     # User action requested


### PR DESCRIPTION
In this way someone can decide during compile time if use string encoding or not.
To disable string encoding via iconv simply compile with

`build$ cmake -DUSE_STRING_ENCODING=OFF ..`