### PR TITLE
Refactoring CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,11 @@
 project (kaitai_struct_cpp_stl_runtime CXX)
 cmake_minimum_required (VERSION 3.3)
 
-set (CMAKE_INCLUDE_CURRENT_DIR ON)
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake)
+
 
 find_package(ZLIB)
-
-find_path(ICONV_INCLUDE_DIRS iconv.h)
-mark_as_advanced(ICONV_INCLUDE_DIRS)
-find_library(ICONV_LIBRARIES NAMES libiconv libiconv-2 c)
-mark_as_advanced(ICONV_LIBRARIES)
-
-set(ICONV_FOUND FALSE)
-if(ICONV_INCLUDE_DIRS AND ICONV_LIBRARIES)
-    SET(ICONV_FOUND TRUE)
-endif()
+find_package(Iconv)
 
 set (HEADERS
     kaitai/kaitaistream.h
@@ -26,32 +18,29 @@ set (SOURCES
 
 set(STRING_ENCODING_TYPE "ICONV" CACHE STRING "Set the way strings have to be encoded (ICONV|NONE|...)")
 
-add_library (${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library (${PROJECT_NAME} SHARED ${SOURCES})
+
+target_include_directories(${PROJECT_NAME} 
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/kaitai>
+    )
+
 
 if (ZLIB_FOUND)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${ZLIB_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${ZLIB_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_ZLIB)
 endif()
-
-if(ICONV_FOUND)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${ICONV_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${ICONV_LIBRARIES})
-endif()
+if(Iconv_FOUND)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Iconv::Iconv)
+ endif()
 
 if (STRING_ENCODING_TYPE STREQUAL "ICONV")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_ICONV)
+   target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_ICONV)
 elseif (STRING_ENCODING_TYPE STREQUAL "NONE")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_NONE)
+   target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_NONE)
 else()
     # User action requested
 endif()
 
-if (WIN32)
-    install(TARGETS ${PROJECT_NAME}
-        RUNTIME DESTINATION lib)
-else()
-    install (TARGETS ${PROJECT_NAME}
-        LIBRARY DESTINATION lib
-    )
-endif()
+include(cmake/KaitaiRuntimeExportConfig.cmake)

--- a/cmake/FindIconv.cmake
+++ b/cmake/FindIconv.cmake
@@ -1,0 +1,38 @@
+# find iconv header
+
+find_package(PkgConfig)
+pkg_check_modules(PC_Iconv QUIET Iconv)
+
+
+set(Iconv_LIBRARIES_NAME libiconv libiconv-2)
+if(UNIX)
+	list(APPEND Iconv_LIBRARIES_NAME c)
+endif()
+
+find_path(Iconv_INCLUDE_DIR
+	NAMES iconv.h
+	PATHS ${PC_Iconv_INCLUDE_DIRS}
+	)
+find_library(Iconv_LIBRARY
+	NAMES ${Iconv_LIBRARIES_NAME}
+	)
+
+mark_as_advanced(Iconv_FOUND Iconv_INCLUDE_DIR Iconv_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Iconv
+	REQUIRED_VARS Iconv_INCLUDE_DIR Iconv_LIBRARY
+	)
+
+if(Iconv_FOUND)
+	set(Iconv_INCLUDE_DIRS "${Iconv_INCLUDE_DIR}")
+	set(Iconv_LIBRARIES "${Iconv_LIBRARY}")
+	if(NOT TARGET Iconv::Iconv)
+		add_library(Iconv::Iconv INTERFACE IMPORTED)
+	endif()
+	set_property(TARGET Iconv::Iconv 
+		PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${Iconv_INCLUDE_DIRS})
+	set_property(TARGET Iconv::Iconv
+		PROPERTY INTERFACE_LINK_LIBRARIES ${Iconv_LIBRARIES})
+
+endif(Iconv_FOUND)

--- a/cmake/KaitaiRuntimeConfig.cmake.in
+++ b/cmake/KaitaiRuntimeConfig.cmake.in
@@ -1,0 +1,11 @@
+include(CMakeFindDependencyMacro)
+get_filename_component(KAITAI_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+list(APPEND CMAKE_MODULE_PATH ${KAITAI_CMAKE_DIR})
+
+message("CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}")
+
+find_dependency(ZLIB)
+find_dependency(Iconv)
+
+include("${CMAKE_CURRENT_LIST_DIR}/KaitaiRuntimeTargets.cmake")

--- a/cmake/KaitaiRuntimeExportConfig.cmake
+++ b/cmake/KaitaiRuntimeExportConfig.cmake
@@ -1,0 +1,74 @@
+include(GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/KaitaiRuntime)
+set(KAITAI_TARGET_NAME KaitaiRuntime-targets)
+
+#------------------------------------------------------------------------------
+#
+# Copy header and library
+
+install (FILES ${HEADERS}
+    DESTINATION  ${CMAKE_INSTALL_INCLUDEDIR}/kaitai
+    )
+
+if (WIN32)
+    install(TARGETS ${PROJECT_NAME}
+        EXPORT ${KAITAI_TARGET_NAME}
+        RUNTIME DESTINATION lib
+            )
+else()
+    install(TARGETS ${PROJECT_NAME}
+        EXPORT ${KAITAI_TARGET_NAME}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+endif()
+
+#------------------------------------------------------------------------------
+#
+# Setup export name
+
+install(EXPORT ${KAITAI_TARGET_NAME}
+  FILE
+    KaitaiRuntimeTargets.cmake
+  NAMESPACE 
+    Kaitai::
+  DESTINATION
+    ${INSTALL_CONFIGDIR}
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME KaitaiRuntime)
+
+
+#------------------------------------------------------------------------------
+#
+# Setup export name
+
+include(CMakePackageConfigHelpers)
+
+# It's used for portable purposes
+export(EXPORT  ${KAITAI_TARGET_NAME}
+    NAMESPACE Kaitai::
+    FILE  ${CMAKE_CURRENT_BINARY_DIR}/KaitaiRuntimeTargets.cmake
+    )
+
+# Creates config file to be found by `find_package`
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/KaitaiRuntimeConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/KaitaiRuntimeConfig.cmake
+    INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+# Configure custom module to be used by the config file
+configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/FindIconv.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/FindIconv.cmake
+    COPYONLY
+    )
+
+install(FILES
+    ${CMAKE_CURRENT_LIST_DIR}/FindIconv.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/KaitaiRuntimeConfig.cmake
+    DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+
+export(PACKAGE KAITAI_RUNTIME)


### PR DESCRIPTION
There are useful configure files a client project can include the runtime project using `find_package` funcion.
There is module to find iconv and include naturely.
