### PR TITLE
Edit for Mac: runtime/cpp_stl/CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(ZLIB)
 
 find_path(ICONV_INCLUDE_DIRS iconv.h)
 mark_as_advanced(ICONV_INCLUDE_DIRS)
-find_library(ICONV_LIBRARIES NAMES libiconv libiconv-2 c)
+find_library(ICONV_LIBRARIES NAMES libiconv libiconv-2 iconv)
 mark_as_advanced(ICONV_LIBRARIES)
 
 set(ICONV_FOUND FALSE)
@@ -27,6 +27,7 @@ set (SOURCES
 set(STRING_ENCODING_TYPE "ICONV" CACHE STRING "Set the way strings have to be encoded (ICONV|NONE|...)")
 
 add_library (${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "kaitai/kaitaistream.h;kaitai/kaitaistruct.h")
 
 if (ZLIB_FOUND)
     target_include_directories(${PROJECT_NAME} PRIVATE ${ZLIB_INCLUDE_DIRS})
@@ -53,5 +54,6 @@ if (WIN32)
 else()
     install (TARGETS ${PROJECT_NAME}
         LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/kaitai
     )
 endif()


### PR DESCRIPTION
Hi, 

On the Mac I was not able to link the symbols `iconv`, `iconv_open` and `iconv_close` called in `runtime/cpp_stl/kaitaistream.cpp`.  This was due to the `find_library ICONV_LIBRARIES` line in `CMakeLists.txt` looking for `libiconv`, when on the Mac it needs to look for `iconv`.  The same line looks for `c` so it was finding `/usr/lib/libc` and not `/usr/lib/libiconv`, which is installed.  `libc` of course can not resolve the `iconv` symbols.  I took out `c` and added `iconv`.  
I also added two lines to install the headers in a `kaitai` subdirectory (as the generated C++ files look for `kaitai/kaitaistruct.h`).  One line to add `PUBLIC_HEADER` to `set_target_properties`, and one line in the `install` target to install the two `.h` files.
Tested on Mac and Linux but not Windows.