### PR TITLE
Fix kstream constructor which uses std::string for initialization

### DIFF
--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -31,7 +31,7 @@ kaitai::kstream::kstream(std::istream* io) {
     init();
 }
 
-kaitai::kstream::kstream(std::string& data): m_io_str(data) {
+kaitai::kstream::kstream(const std::string& data): m_io_str(data) {
     m_io = &m_io_str;
     init();
 }

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -41,7 +41,7 @@ public:
      * buffer.
      * \param data data buffer to use for this Kaitai Stream
      */
-    kstream(std::string& data);
+    kstream(const std::string& data);
 
     void close();
 


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/io/basic_istringstream/basic_istringstream (3) takes `const std::string&` so it looks appropriate to take the same in `kaitai::kstream` constructor working with `std::string`.

Resolves https://github.com/kaitai-io/kaitai_struct/issues/806