### PR TITLE
GitHub Actions CI for running unit tests

### DIFF
--- a/.build/build
+++ b/.build/build
@@ -1,0 +1,8 @@
+#!/bin/sh -ef
+
+cd $(dirname "$0")/..
+
+mkdir -p build
+cd build
+cmake ..
+cmake --build .

--- a/.build/build
+++ b/.build/build
@@ -1,6 +1,6 @@
 #!/bin/sh -ef
 
-cd $(dirname "$0")/..
+cd "$(dirname "$0")"/..
 
 mkdir -p build
 cd build

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -10,6 +10,7 @@ Requires:
 
 [CmdletBinding()]
 param (
+    [Parameter(Mandatory=$true)]
     [string] $GTestPath
 )
 
@@ -18,8 +19,12 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $PSDefaultParameterValues['*:ErrorAction']='Stop'
 
-$null = New-Item ..\build -ItemType Directory -Force
-Push-Location ..\build
+# Go to repo root
+$repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+Push-Location $repoRoot
+
+$null = New-Item build -ItemType Directory -Force
+cd build
 
 cmake -DCMAKE_PREFIX_PATH="$GTestPath" -DSTRING_ENCODING_TYPE=NONE ..
 cmake --build . --config Debug

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -1,0 +1,28 @@
+<#
+.DESCRIPTION
+Builds Kaitai Struct C++ runtime library and unit tests
+
+Requires:
+- MSVC native tools installed and available in the command prompt
+- cmake/ctest available (normally installed with MSVC native tools)
+- GTest installed, path passed in `-GTestPath`
+#>
+
+[CmdletBinding()]
+param (
+    [string] $GTestPath
+)
+
+# Standard boilerplate
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$PSDefaultParameterValues['*:ErrorAction']='Stop'
+
+Push-Location ..\build
+
+cmake -DCMAKE_PREFIX_PATH="$GTestPath" -DSTRING_ENCODING_TYPE=NONE ..
+cmake --build . --config Debug
+cp $GTestPath\debug\bin\*.dll tests\Debug
+cp Debug\kaitai_struct_cpp_stl_runtime.dll tests\Debug
+
+Pop-Location

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -18,6 +18,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $PSDefaultParameterValues['*:ErrorAction']='Stop'
 
+$null = New-Item ..\build -ItemType Directory -Force
 Push-Location ..\build
 
 cmake -DCMAKE_PREFIX_PATH="$GTestPath" -DSTRING_ENCODING_TYPE=NONE ..

--- a/.build/run-unittest
+++ b/.build/run-unittest
@@ -1,6 +1,6 @@
 #!/bin/sh -ef
 
-cd $(dirname "$0")/..
+cd "$(dirname "$0")"/..
 
 cd build/tests
 ./unittest

--- a/.build/run-unittest
+++ b/.build/run-unittest
@@ -1,0 +1,6 @@
+#!/bin/sh -ef
+
+cd $(dirname "$0")/..
+
+cd build/tests
+./unittest

--- a/.build/run-unittest.ps1
+++ b/.build/run-unittest.ps1
@@ -8,7 +8,11 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $PSDefaultParameterValues['*:ErrorAction']='Stop'
 
-Push-Location ..\build
+# Go to repo root
+$repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+Push-Location $repoRoot
+
+cd build
 
 # Use ctest
 #ctest -C Debug --output-on-failure

--- a/.build/run-unittest.ps1
+++ b/.build/run-unittest.ps1
@@ -1,0 +1,19 @@
+<#
+.DESCRIPTION
+Runs unit tests on Windows
+#>
+
+# Standard boilerplate
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$PSDefaultParameterValues['*:ErrorAction']='Stop'
+
+Push-Location ..\build
+
+# Use ctest
+#ctest -C Debug --output-on-failure
+
+# Run gtest-generated binary directly, produces more detailed output
+./tests/Debug/unittest.exe
+
+Pop-Location

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,17 @@ jobs:
         run: .build/build
       - name: unittest
         run: .build/run-unittest
+
+  windows:
+    runs-on: windows-latest
+    # NB: see https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md for what's available in this image
+    steps:
+      - uses: actions/checkout@v1
+      - name: restore
+        run: |
+          C:\vcpkg\bootstrap-vcpkg.bat
+          C:\vcpkg\vcpkg install gtest
+      - name: build
+        run: .build\build.ps1 -GTestPath C:\vcpkg\installed\x64-windows
+      - name: unittest
+        run: .build\run-unittest.ps1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: restore
+        run: |
+          apt-get install -y libgtest-dev
+      - name: build
+        run: .build/build
+      - name: unittest
+        run: .build/run-unittest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: restore
         run: |
           C:\vcpkg\bootstrap-vcpkg.bat
-          C:\vcpkg\vcpkg install gtest
+          C:\vcpkg\vcpkg install gtest:x64-windows
       - name: build
         run: .build\build.ps1 -GTestPath C:\vcpkg\installed\x64-windows
       - name: unittest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: restore
         run: |
-          apt-get install -y libgtest-dev
+          sudo apt-get install -y libgtest-dev
       - name: build
         run: .build/build
       - name: unittest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-latest
     # NB: see https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md for what's available in this image
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: restore
         run: |
           C:\vcpkg\bootstrap-vcpkg.bat

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -246,7 +246,7 @@ public:
         if (val < 0) {
             buf[0] = '-';
             // get absolute value without undefined behavior (https://stackoverflow.com/a/12231604)
-            unsigned_to_decimal(-static_cast<uint64_t>(val), &buf[1]);
+            unsigned_to_decimal(-static_cast<int64_t>(val), &buf[1]);
         } else {
             unsigned_to_decimal(val, buf);
         }


### PR DESCRIPTION
* Adds GitHub Actions-based CI workflows to build library + unit tests and do a basic test run.
* Implements 2x2 scripts in `.build/` for Linux/Windows and build/run steps.
* Adds CI workflows for Linux and Windows.
* Fixes one warning in .h file (problem proven by [CI failing run](https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/actions/runs/5154249448/jobs/9282479655), successful unit tests prove that nothing has been broken after the fix).

Known caveats:

* Tests rely on availability of GTest, but different OSes have different ways to install and versions to offer:
  * For Linux, it's installed in CI using apt (takes ~15-20s). As of now, this gets *GTest 1.11.0-3*.
  * For Windows, it's more complicated: there's no binary build, so we utilize vcpkg to download and build gtest during CI (slightly longer: takes ~50-110s). As of now, this gets *GTest 1.13.0*.
* Versions of OS/compilers are not fixed and might change at will by GitHub. As of now, they are:
  * Linux
    * Ubuntu 22.04.2 LTS
    * GCC 11.3.0
  * Windows:
    * Microsoft Windows Server 2022 Datacenter, 10.0.20348
    * MSVC 19.35.32217.1