### PR TITLE
Add CI support for gcc 4.1.2 / Ubuntu 7.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,11 @@ jobs:
           docker pull icomputer7/ancient-ubuntu-docker:gutsy
       - name: docker create start
         run: |
-          docker create --name u710 --label u710 --workdir /__w/kaitai_struct_cpp_stl_runtime/kaitai_struct_cpp_stl_runtime -v "${{ github.workspace }}":"/__w" --entrypoint "tail" icomputer7/ancient-ubuntu-docker:gutsy "-f" "/dev/null"
+          docker create --name u710 --label u710 --workdir /w -v "${{ github.workspace }}":"/w" --entrypoint "tail" icomputer7/ancient-ubuntu-docker:gutsy "-f" "/dev/null"
           docker start u710
       - name: restore
         run: |
-          docker exec u710 sh -c 'apt-get update && apt-get -y --no-install-recommends install make g++'
+          docker exec u710 sh -c 'pwd && ls -al && apt-get update && apt-get -y --no-install-recommends install make g++'
       - name: build
         run: |
           docker exec u710 sh -c 'make -f Makefile.gcc4'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,21 +39,23 @@ jobs:
   #   To work around this, we use plain GNU make(1) and supply custom Makefile.gcc4.
   linux_ubuntu_7_10:
     runs-on: ubuntu-latest
+    container: 'icomputer7/ancient-ubuntu-docker:gutsy'
     steps:
-      - uses: actions/checkout@v3
       - name: restore
-        container: 'icomputer7/ancient-ubuntu-docker:gutsy'
         run: |
           apt-get update
           apt-get -y --no-install-recommends install \
               git \
               make \
               g++
+      # Can't use actions/checkout@v3, as it depends on NodeJS, which is not available in this image
+      - name: checkout
+        run: |
+          git clone ${{ github.repositoryUrl }} .
+          git checkout ${{ github.sha }}
       - name: build
-        container: 'icomputer7/ancient-ubuntu-docker:gutsy'
         run: make -f Makefile.gcc4
       - name: unittest
-        container: 'icomputer7/ancient-ubuntu-docker:gutsy'
         run: build/unittest
 
   windows:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           docker pull icomputer7/ancient-ubuntu-docker:gutsy
       - name: docker create start
         run: |
-          docker create --name u710 --label u710 --workdir /w -v "${{ github.workspace }}":"/w" --entrypoint "tail" icomputer7/ancient-ubuntu-docker:gutsy "-f" "/dev/null"
+          docker create --name u710 --label u710 --workdir /w -v "$GITHUB_WORKSPACE":"/w" --entrypoint "tail" icomputer7/ancient-ubuntu-docker:gutsy "-f" "/dev/null"
           docker start u710
       - name: restore
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,40 @@ jobs:
       - name: unittest
         run: .build/run-unittest
 
+  # Builds and runs tests on Ubuntu 7.10.
+  # It ships with:
+  #
+  # gcc (GCC) 4.1.3 20070929 (prerelease) (Ubuntu 4.1.2-16ubuntu2)
+  # Copyright (C) 2006 Free Software Foundation, Inc.
+  #
+  # cmake version 2.4-patch 7
+  #
+  # This one is challenging:
+  #
+  # * For gcc, vast majority of C++11 features are missing from this release (many were added around GCC 4.3 and 4.4).
+  #   Some C99 features are also missing. C++98 support seems to be full-featued.
+  #
+  # * Modern GTest doesn't work in this environment, as GTest v1.12.x requires C++11 and modern GTest v1.13+ requires C++14.
+  #   To work around this, we supply nano substitute of GTest (tests/gtest-nano.h), partially compatible with API.
+  #
+  # * CMake is way too old to be usable without major rewrite of all the CMakeLists.txt to use ancient/deprecated syntax.
+  #   To work around this, we use plain GNU make(1) and supply custom Makefile.gcc4.
+  linux_ubuntu_7_10:
+    runs-on: icomputer7/ancient-ubuntu-docker:gutsy
+    steps:
+      - name: restore
+        run: |
+          sudo apt-get update
+          sudo apt-get -y --no-install-recommends install \
+              git \
+              make \
+              g++
+      - uses: actions/checkout@v3
+      - name: build
+        run: make -f Makefile.gcc4
+      - name: unittest
+        run: build/unittest
+
   windows:
     runs-on: windows-latest
     # NB: see https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md for what's available in this image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,9 @@ jobs:
   # * CMake is way too old to be usable without major rewrite of all the CMakeLists.txt to use ancient/deprecated syntax.
   #   To work around this, we use plain GNU make(1) and supply custom Makefile.gcc4.
   linux_ubuntu_7_10:
-    runs-on: icomputer7/ancient-ubuntu-docker:gutsy
+    runs-on: ubuntu-latest
+    container:
+      image: icomputer7/ancient-ubuntu-docker:gutsy
     steps:
       - name: restore
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,9 @@ jobs:
       # Can't use actions/checkout@v3, as it depends on NodeJS, which is not available in this image
       - name: checkout
         run: |
-          git clone ${{ github.repositoryUrl }} .
+          git clone ${{ github.repositoryUrl }} __repo
+          find __repo -mindepth 1 -maxdepth 1 -print0 | xargs -0 -i mv '{}' .
+          rmdir __repo
           git checkout ${{ github.sha }}
       - name: build
         run: make -f Makefile.gcc4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,11 @@ jobs:
   #
   # This one is challenging:
   #
+  # * It's impossible to run git clone inside this container (as old git will use ancient protocols not supported anymore
+  #   by GitHub, and also standard `actions/checkout@v3` will depend on NodeJS/npm, which are not available in this container).
+  #   To work around this, we start/stop container manually and use targeted execution of specific build/run commands only
+  #   inside the container, keeping git and networking stuff out.
+  #
   # * For gcc, vast majority of C++11 features are missing from this release (many were added around GCC 4.3 and 4.4).
   #   Some C99 features are also missing. C++98 support seems to be full-featued.
   #
@@ -39,28 +44,28 @@ jobs:
   #   To work around this, we use plain GNU make(1) and supply custom Makefile.gcc4.
   linux_ubuntu_7_10:
     runs-on: ubuntu-latest
-    container: 'icomputer7/ancient-ubuntu-docker:gutsy'
     steps:
+      - uses: actions/checkout@v3
+      - name: docker pull
+        run: |
+          docker pull icomputer7/ancient-ubuntu-docker:gutsy
+      - name: docker create start
+        run: |
+          docker create --name u710 --label u710 --workdir /__w/kaitai_struct_cpp_stl_runtime/kaitai_struct_cpp_stl_runtime -v "${{ github.workspace }}":"/__w" --entrypoint "tail" icomputer7/ancient-ubuntu-docker:gutsy "-f" "/dev/null"
+          docker start u710
       - name: restore
         run: |
-          apt-get update
-          apt-get -y --no-install-recommends install \
-              git-core \
-              make \
-              g++
-          git --version
-      # Can't use actions/checkout@v3, as it depends on NodeJS, which is not available in this image
-      - name: checkout
-        run: |
-          git clone https://github.com/${{ github.repository }}/ __repo
-          find __repo -mindepth 1 -maxdepth 1 -print0 | xargs -0 -i mv '{}' .
-          rmdir __repo
-          git checkout ${{ github.sha }}
+          docker exec u710 sh -c 'apt-get update && apt-get -y --no-install-recommends install make g++'
       - name: build
-        run: make -f Makefile.gcc4
+        run: |
+          docker exec u710 sh -c 'make -f Makefile.gcc4'
       - name: unittest
-        run: build/unittest
-
+        run: |
+          docker exec u710 sh -c 'build/unittest'
+      - name: docker shutdown
+        run: |
+          docker stop u710
+          docker rm u710
   windows:
     runs-on: windows-latest
     # NB: see https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md for what's available in this image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,14 +45,13 @@ jobs:
         run: |
           apt-get update
           apt-get -y --no-install-recommends install \
-              git \
+              git-core \
               make \
               g++
           git --version
       # Can't use actions/checkout@v3, as it depends on NodeJS, which is not available in this image
       - name: checkout
         run: |
-          git --version
           git clone ${{ github.repositoryUrl }} .
           git checkout ${{ github.sha }}
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       # Can't use actions/checkout@v3, as it depends on NodeJS, which is not available in this image
       - name: checkout
         run: |
-          git clone ${{ github.repositoryUrl }} __repo
+          git clone https://github.com/${{ github.repository }}/ __repo
           find __repo -mindepth 1 -maxdepth 1 -print0 | xargs -0 -i mv '{}' .
           rmdir __repo
           git checkout ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,20 +39,21 @@ jobs:
   #   To work around this, we use plain GNU make(1) and supply custom Makefile.gcc4.
   linux_ubuntu_7_10:
     runs-on: ubuntu-latest
-    container:
-      image: icomputer7/ancient-ubuntu-docker:gutsy
     steps:
+      - uses: actions/checkout@v3
       - name: restore
+        container: 'icomputer7/ancient-ubuntu-docker:gutsy'
         run: |
           apt-get update
           apt-get -y --no-install-recommends install \
               git \
               make \
               g++
-      - uses: actions/checkout@v3
       - name: build
+        container: 'icomputer7/ancient-ubuntu-docker:gutsy'
         run: make -f Makefile.gcc4
       - name: unittest
+        container: 'icomputer7/ancient-ubuntu-docker:gutsy'
         run: build/unittest
 
   windows:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
     steps:
       - name: restore
         run: |
-          sudo apt-get update
-          sudo apt-get -y --no-install-recommends install \
+          apt-get update
+          apt-get -y --no-install-recommends install \
               git \
               make \
               g++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,11 @@ jobs:
               git \
               make \
               g++
+          git --version
       # Can't use actions/checkout@v3, as it depends on NodeJS, which is not available in this image
       - name: checkout
         run: |
+          git --version
           git clone ${{ github.repositoryUrl }} .
           git checkout ${{ github.sha }}
       - name: build

--- a/Makefile.gcc4
+++ b/Makefile.gcc4
@@ -26,8 +26,8 @@ $(BUILD_DIR):
 $(BUILD_DIR)/unittest: $(OBJS)
 	$(CXX) $(CXXFLAGS) -o build/unittest $(OBJS) $(LFLAGS) $(LIBS)
 
-$(BUILD_DIR)/kaitaistream.o: kaitai/kaitaistream.cpp
+$(BUILD_DIR)/kaitaistream.o: kaitai/kaitaistream.cpp kaitai/kaitaistream.h
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $(DEFINES) -c $< -o $@
 
-$(BUILD_DIR)/unittest.o: tests/unittest.cpp tests/gtest-nano.h
+$(BUILD_DIR)/unittest.o: tests/unittest.cpp tests/gtest-nano.h kaitai/kaitaistream.h
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $(DEFINES) -c $< -o $@

--- a/Makefile.gcc4
+++ b/Makefile.gcc4
@@ -1,0 +1,33 @@
+# Makefile for ancient gcc4 (tested on Ubuntu 7.10 with 4.1.2-16ubuntu2)
+# Compiles Kaitai Struct C++ runtime and tests
+
+BUILD_DIR := build
+
+SOURCES := \
+	kaitai/kaitaistream.cpp \
+	tests/unittest.cpp
+
+OBJS := \
+	$(BUILD_DIR)/kaitaistream.o \
+	$(BUILD_DIR)/unittest.o
+
+DEFINES := -DKS_STR_ENCODING_ICONV -DGTEST_NANO
+
+LFLAGS :=
+LIBS :=
+
+INCLUDES := -I.
+
+all: $(BUILD_DIR) $(BUILD_DIR)/unittest
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/unittest: $(OBJS)
+	$(CXX) $(CXXFLAGS) -o build/unittest $(OBJS) $(LFLAGS) $(LIBS)
+
+$(BUILD_DIR)/kaitaistream.o: kaitai/kaitaistream.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(DEFINES) -c $< -o $@
+
+$(BUILD_DIR)/unittest.o: tests/unittest.cpp tests/gtest-nano.h
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(DEFINES) -c $< -o $@

--- a/Makefile.gcc4
+++ b/Makefile.gcc4
@@ -13,8 +13,8 @@ OBJS := \
 
 DEFINES := -DKS_STR_ENCODING_ICONV -DGTEST_NANO
 
-LFLAGS :=
-LIBS :=
+LDFLAGS :=
+LDLIBS :=
 
 INCLUDES := -I.
 
@@ -24,7 +24,7 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/unittest: $(OBJS)
-	$(CXX) $(CXXFLAGS) -o build/unittest $(OBJS) $(LFLAGS) $(LIBS)
+	$(CXX) $(CXXFLAGS) -o build/unittest $(OBJS) $(LDFLAGS) $(LDLIBS)
 
 $(BUILD_DIR)/kaitaistream.o: kaitai/kaitaistream.cpp kaitai/kaitaistream.h
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $(DEFINES) -c $< -o $@

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -331,7 +331,7 @@ uint64_t kaitai::kstream::read_bits_int_be(int n) {
         res = m_bits >> -bits_needed; // shift unneeded bits out
     }
 
-    uint64_t mask = (UINT64_C(1) << m_bits_left) - 1; // `m_bits_left` is in range 0..7, so `(1 << 64)` does not have to be considered
+    uint64_t mask = (static_cast<uint64_t>(1) << m_bits_left) - 1; // `m_bits_left` is in range 0..7, so `(1 << 64)` does not have to be considered
     m_bits &= mask;
 
     return res;
@@ -375,7 +375,7 @@ uint64_t kaitai::kstream::read_bits_int_le(int n) {
     m_bits_left = -bits_needed & 7; // `-bits_needed mod 8`
 
     if (n < 64) {
-        uint64_t mask = (UINT64_C(1) << n) - 1;
+        uint64_t mask = (static_cast<uint64_t>(1) << n) - 1;
         res &= mask;
     }
     // if `n == 64`, do nothing

--- a/tests/gtest-nano.h
+++ b/tests/gtest-nano.h
@@ -1,0 +1,66 @@
+// gtest-nano.h implements very minimalistic GTest-compatible API that can be used to run tests in older
+// (C++98-compatible) environments.
+
+#include <iostream>
+#include <vector>
+
+namespace testing {
+    struct TestInfo {
+        const char* suite;
+        const char* name;
+        void (*testFunc)();
+    };
+
+    std::vector<TestInfo> g_tests;
+    bool g_testPass;
+    bool g_allPass;
+
+    void InitGoogleTest(int* argc, char** argv) {
+        std::cout << "[----------] gtest-nano: starting up\n";
+    }
+
+    int runAllTests() {
+        std::cout << "[==========] Running " << g_tests.size() << " tests.\n";
+
+        g_allPass = true;
+        for (std::vector<TestInfo>::const_iterator it = g_tests.begin(); it != g_tests.end(); ++it) {
+            const TestInfo& test = *it;
+            g_testPass = true;
+            std::cout << "[ RUN      ] " << test.suite << "." << test.name << "\n";
+            test.testFunc();
+            std::cout << (g_testPass ? "[       OK ] " : "[  FAILED  ] ") <<  test.suite << "." << test.name << "\n";
+            g_allPass &= g_testPass;
+        }
+
+        return g_allPass ? 0 : 1;
+    }
+}
+
+// Defines test function and registers it in global list of tests
+#define TEST(suite, name)                                    \
+    void Test_##suite##_##name();                            \
+    namespace {                                              \
+        struct Register_##suite##_##name {                   \
+            Register_##suite##_##name() {                    \
+                ::testing::TestInfo info = {                 \
+                    #suite,                                  \
+                    #name,                                   \
+                    Test_##suite##_##name                    \
+                };                                           \
+                ::testing::g_tests.push_back(info);          \
+            }                                                \
+        };                                                   \
+        Register_##suite##_##name register_##suite##_##name; \
+    }                                                        \
+    void Test_##suite##_##name()
+
+// Assertion macro
+#define EXPECT_EQ(a, b)                           \
+    do {                                          \
+        if ((a) == (b)) {                         \
+        } else {                                  \
+            ::testing::g_testPass = false;        \
+        }                                         \
+    } while (false)
+
+#define RUN_ALL_TESTS() ::testing::runAllTests()

--- a/tests/gtest-nano.h
+++ b/tests/gtest-nano.h
@@ -6,8 +6,8 @@
 
 namespace testing {
     struct TestInfo {
-        const char* suite;
-        const char* name;
+        const char *suite;
+        const char *name;
         void (*testFunc)();
     };
 
@@ -15,7 +15,7 @@ namespace testing {
     bool g_testPass;
     bool g_allPass;
 
-    void InitGoogleTest(int* argc, char** argv) {
+    void InitGoogleTest(int *argc, char **argv) {
         std::cout << "[----------] gtest-nano: starting up\n";
     }
 
@@ -24,7 +24,7 @@ namespace testing {
 
         g_allPass = true;
         for (std::vector<TestInfo>::const_iterator it = g_tests.begin(); it != g_tests.end(); ++it) {
-            const TestInfo& test = *it;
+            const TestInfo &test = *it;
             g_testPass = true;
             std::cout << "[ RUN      ] " << test.suite << "." << test.name << "\n";
             test.testFunc();

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1,4 +1,8 @@
+#ifdef GTEST_NANO
+#include "tests/gtest-nano.h"
+#else
 #include <gtest/gtest.h>
+#endif
 
 #include "kaitai/kaitaistream.h"
 
@@ -46,7 +50,7 @@ TEST(KaitaiStreamTest, to_string_int32)
 
 TEST(KaitaiStreamTest, to_string_uint64)
 {
-    EXPECT_EQ(kaitai::kstream::to_string(std::numeric_limits<uint64_t>::min()), "0");
+    EXPECT_EQ(kaitai::kstream::to_string(std::numeric_limits<uint64_t>::min()), "42");
     EXPECT_EQ(kaitai::kstream::to_string(std::numeric_limits<uint64_t>::max()), "18446744073709551615");
 }
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -50,7 +50,7 @@ TEST(KaitaiStreamTest, to_string_int32)
 
 TEST(KaitaiStreamTest, to_string_uint64)
 {
-    EXPECT_EQ(kaitai::kstream::to_string(std::numeric_limits<uint64_t>::min()), "42");
+    EXPECT_EQ(kaitai::kstream::to_string(std::numeric_limits<uint64_t>::min()), "0");
     EXPECT_EQ(kaitai::kstream::to_string(std::numeric_limits<uint64_t>::max()), "18446744073709551615");
 }
 


### PR DESCRIPTION
This add CI support for ancient Ubuntu 7.10 and ancient gcc 4.1.2. This PR is based off https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/pull/56, and it supposed to be reviewed after that.

Ubuntu 7.10 ships with:

```
gcc (GCC) 4.1.3 20070929 (prerelease) (Ubuntu 4.1.2-16ubuntu2)
Copyright (C) 2006 Free Software Foundation, Inc.

cmake version 2.4-patch 7
```

## Challenges

This one is challenging:

* It's impossible to run git clone inside this container (as old git would use older protocols not supported anymore by GitHub, and also standard `actions/checkout@v3` will depend on NodeJS/npm, which are not available in this container). To work around this, we start/stop container manually and use targeted execution of specific build/run commands only inside the container, keeping git and networking stuff out.

* For gcc, vast majority of C++11 features are missing from this release (many were added around GCC 4.3 and 4.4). Some C99 features are also missing. C++98 support seems to be full-featured.

* Modern GTest doesn't work in this environment, as GTest v1.12.x requires C++11 and modern GTest v1.13+ requires C++14. To work around this, we supply nano substitute of GTest (tests/gtest-nano.h), partially compatible with API. The only difference is we need to swap `#include <gtest/gtest.h>` to something different, so I've added GTEST_NANO define to distinguish between these two options.

* CMake is way too old to be usable without major rewrite of all the CMakeLists.txt to use ancient/deprecated syntax. To work around this, we use plain GNU make(1) and supply custom Makefile.gcc4.

## Problems found and fixed along with this implementation

* UINT64_C used in kaitaistream.cpp is not available in this gcc, as this is part of C99, not C++98 (see [this CI report for failure](https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/actions/runs/5291489434/jobs/9577107282)). Fixed by replacing with static_cast.

## Extra stuff

Using custom test implementation also requires minimal testing. Here's an example of results of what happens when we introduce error in the test expectations:

* Ubuntu 22.04 (with regular GTest): https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/actions/runs/5291541904/jobs/9577225385
* Ubuntu 7.10 (with "GTest" nano): https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/actions/runs/5291541904/jobs/9577225574