### PR TITLE
Basic bytes_to_str tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,13 +30,6 @@ set(STRING_ENCODING_TYPE "ICONV" CACHE STRING "Set the way strings have to be en
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-# Maximum warnings emission, treat all warnings as errors
-if (MSVC)
-    add_compile_options(/W4 /WX)
-else()
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
-
 add_library (${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
 set_property(TARGET ${PROJECT_NAME} PROPERTY PUBLIC_HEADER ${HEADERS})
 
@@ -51,13 +44,7 @@ if(ICONV_FOUND)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${ICONV_LIBRARIES})
 endif()
 
-if (STRING_ENCODING_TYPE STREQUAL "ICONV")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_ICONV)
-elseif (STRING_ENCODING_TYPE STREQUAL "NONE")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_NONE)
-else()
-    # User action requested
-endif()
+include(Common.cmake)
 
 install(TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION lib

--- a/Common.cmake
+++ b/Common.cmake
@@ -1,0 +1,7 @@
+if (STRING_ENCODING_TYPE STREQUAL "ICONV")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_ICONV)
+elseif (STRING_ENCODING_TYPE STREQUAL "NONE")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_STR_ENCODING_NONE)
+else()
+    # User action requested
+endif()

--- a/Common.cmake
+++ b/Common.cmake
@@ -5,3 +5,10 @@ elseif (STRING_ENCODING_TYPE STREQUAL "NONE")
 else()
     # User action requested
 endif()
+
+# Maximum warnings emission, treat all warnings as errors
+if (MSVC)
+    add_compile_options(/W4 /WX)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,14 @@
+project (unittest CXX)
+
 find_package(GTest REQUIRED)
 
 add_executable(unittest unittest.cpp)
 
+include(../Common.cmake)
+
 target_include_directories(unittest PRIVATE ${CMAKE_SOURCE_DIR})
 
 # Link the test executable with the main library and the test framework/library
-target_link_libraries(unittest PRIVATE ${PROJECT_NAME} GTest::GTest GTest::Main)
+target_link_libraries(unittest PRIVATE kaitai_struct_cpp_stl_runtime GTest::GTest GTest::Main)
 
 add_test(NAME unittest COMMAND unittest)

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -66,6 +66,7 @@ TEST(KaitaiStreamTest, bytes_to_str_ascii)
     EXPECT_EQ(res, "Hello, world!");
 }
 
+#ifndef KS_STR_ENCODING_NONE
 TEST(KaitaiStreamTest, bytes_to_str_iso8859_1)
 {
     auto res = kaitai::kstream::bytes_to_str("\xC4\xD6\xDC\xE4\xF6\xFC\xDF", "ISO8859-1");
@@ -78,12 +79,19 @@ TEST(KaitaiStreamTest, bytes_to_str_gb2312)
     EXPECT_EQ(res, "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C");
 }
 
+TEST(KaitaiStreamTest, bytes_to_str_cp437)
+{
+    auto res = kaitai::kstream::bytes_to_str("\xCC\xB2\x40", "cp437");
+    EXPECT_EQ(res, "\xE2\x95\xA0\xE2\x96\x93\x40");
+}
+
 TEST(KaitaiStreamTest, bytes_to_str_utf16_le)
 {
     // NB: UTF16 bytes representation will have binary zeroes in the middle, so we need to convert it to std::string with explicit length
     auto res = kaitai::kstream::bytes_to_str(std::string("\x41\x00\x42\x00\x91\x25\x70\x24", 8), "UTF-16LE");
     EXPECT_EQ(res, "AB\xE2\x96\x91\xE2\x91\xB0");
 }
+#endif
 
 int main(int argc, char** argv)
 {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -60,6 +60,31 @@ TEST(KaitaiStreamTest, to_string_int64)
     EXPECT_EQ(kaitai::kstream::to_string(std::numeric_limits<int64_t>::max()), "9223372036854775807");
 }
 
+TEST(KaitaiStreamTest, bytes_to_str_ascii)
+{
+    std::string res = kaitai::kstream::bytes_to_str("Hello, world!", "ASCII");
+    EXPECT_EQ(res, "Hello, world!");
+}
+
+TEST(KaitaiStreamTest, bytes_to_str_iso8859_1)
+{
+    auto res = kaitai::kstream::bytes_to_str("\xC4\xD6\xDC\xE4\xF6\xFC\xDF", "ISO8859-1");
+    EXPECT_EQ(res, "\xC3\x84\xC3\x96\xC3\x9C\xC3\xA4\xC3\xB6\xC3\xBC\xC3\x9F");
+}
+
+TEST(KaitaiStreamTest, bytes_to_str_gb2312)
+{
+    auto res = kaitai::kstream::bytes_to_str("\xC4\xE3\xBA\xC3\xCA\xC0\xBD\xE7", "GB2312");
+    EXPECT_EQ(res, "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C");
+}
+
+TEST(KaitaiStreamTest, bytes_to_str_utf16_le)
+{
+    // NB: UTF16 bytes representation will have binary zeroes in the middle, so we need to convert it to std::string with explicit length
+    auto res = kaitai::kstream::bytes_to_str(std::string("\x41\x00\x42\x00\x91\x25\x70\x24", 8), "UTF-16LE");
+    EXPECT_EQ(res, "AB\xE2\x96\x91\xE2\x91\xB0");
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -69,26 +69,26 @@ TEST(KaitaiStreamTest, bytes_to_str_ascii)
 #ifndef KS_STR_ENCODING_NONE
 TEST(KaitaiStreamTest, bytes_to_str_iso8859_1)
 {
-    auto res = kaitai::kstream::bytes_to_str("\xC4\xD6\xDC\xE4\xF6\xFC\xDF", "ISO8859-1");
+    std::string res = kaitai::kstream::bytes_to_str("\xC4\xD6\xDC\xE4\xF6\xFC\xDF", "ISO8859-1");
     EXPECT_EQ(res, "\xC3\x84\xC3\x96\xC3\x9C\xC3\xA4\xC3\xB6\xC3\xBC\xC3\x9F");
 }
 
 TEST(KaitaiStreamTest, bytes_to_str_gb2312)
 {
-    auto res = kaitai::kstream::bytes_to_str("\xC4\xE3\xBA\xC3\xCA\xC0\xBD\xE7", "GB2312");
+    std::string res = kaitai::kstream::bytes_to_str("\xC4\xE3\xBA\xC3\xCA\xC0\xBD\xE7", "GB2312");
     EXPECT_EQ(res, "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C");
 }
 
 TEST(KaitaiStreamTest, bytes_to_str_cp437)
 {
-    auto res = kaitai::kstream::bytes_to_str("\xCC\xB2\x40", "cp437");
+    std::string res = kaitai::kstream::bytes_to_str("\xCC\xB2\x40", "cp437");
     EXPECT_EQ(res, "\xE2\x95\xA0\xE2\x96\x93\x40");
 }
 
 TEST(KaitaiStreamTest, bytes_to_str_utf16_le)
 {
     // NB: UTF16 bytes representation will have binary zeroes in the middle, so we need to convert it to std::string with explicit length
-    auto res = kaitai::kstream::bytes_to_str(std::string("\x41\x00\x42\x00\x91\x25\x70\x24", 8), "UTF-16LE");
+    std::string res = kaitai::kstream::bytes_to_str(std::string("\x41\x00\x42\x00\x91\x25\x70\x24", 8), "UTF-16LE");
     EXPECT_EQ(res, "AB\xE2\x96\x91\xE2\x91\xB0");
 }
 #endif


### PR DESCRIPTION
This adds basic tests for `bytes_to_str`. Supposed to be setting the baseline and being equivalent for different implementations that I'd like to add.

Pretty straightforward, a few notes:

* Does not risk non-ASCII, so deliberately stays in `\xFF` mode for all strings (both non-UTF8 and UTF8).
* We need to propagate KS_STR_ENCODING_xx to test units as well, for that it includes a small refactoring to extract the common setting part in both CMakeLists.