### PR TITLE
Encoding-related exceptions

### DIFF
--- a/kaitai/exceptions.h
+++ b/kaitai/exceptions.h
@@ -20,6 +20,41 @@
 namespace kaitai {
 
 /**
+ * Common ancestor for all errors related to `bytes_to_str` operation. Also used
+ * to signal misc non-specific `bytes_to_str` failures.
+ */
+class bytes_to_str_error: public std::runtime_error {
+public:
+    bytes_to_str_error(const std::string what):
+        std::runtime_error(std::string("bytes_to_str error: ") + what) {}
+
+    virtual ~bytes_to_str_error() KS_NOEXCEPT {};
+};
+
+/**
+ * Exception to signal that `bytes_to_str` operation was requested to use some encoding
+ * that is not available in given runtime environment.
+ */
+class unknown_encoding: public bytes_to_str_error {
+public:
+    unknown_encoding(const std::string enc_name):
+        bytes_to_str_error(std::string("unknown encoding: `") + enc_name + std::string("`")) {}
+
+    virtual ~unknown_encoding() KS_NOEXCEPT {};
+};
+
+/**
+ * Exception to signal that `bytes_to_str` operation failed to decode given byte sequence.
+ */
+class illegal_seq_in_encoding: public bytes_to_str_error {
+public:
+    illegal_seq_in_encoding(const std::string what):
+        bytes_to_str_error("illegal sequence: " + what) {}
+
+    virtual ~illegal_seq_in_encoding() KS_NOEXCEPT {};
+};
+
+/**
  * Common ancestor for all error originating from Kaitai Struct usage.
  * Stores KSY source path, pointing to an element supposedly guilty of
  * an error.

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -831,7 +831,7 @@ std::string kaitai::kstream::bytes_to_str(const std::string src, int codepage) {
         if (MultiByteToWideChar(codepage, MB_ERR_INVALID_CHARS, src.c_str(), src_len, &utf16[0], utf16_len) == 0) {
             auto err = GetLastError();
             if (err == ERROR_NO_UNICODE_TRANSLATION) {
-                throw illegal_seq_in_encoding("no info")
+                throw illegal_seq_in_encoding("no info");
             } else {
                 throw bytes_to_str_error("MultiByteToWideChar conversion error");
             }

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -698,7 +698,7 @@ std::string kaitai::kstream::bytes_to_str(const std::string src, const char *src
             } else if (errno == EILSEQ) {
                 throw illegal_seq_in_encoding("no info");
             } else {
-                throw bytes_to_str_error(std::to_string(errno));
+                throw bytes_to_str_error(to_string(errno));
             }
         } else {
             // conversion successful

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -783,7 +783,7 @@ std::string kaitai::kstream::bytes_to_str(const std::string src, const char *src
     // Step 1: convert encoding name to codepage number
     int codepage = encoding_to_win_codepage(src_enc);
     if (codepage == KAITAI_CP_UNSUPPORTED) {
-        throw std::unknown_encoding(src_enc);
+        throw unknown_encoding(src_enc);
     }
     return bytes_to_str(src, codepage);
 }
@@ -843,13 +843,13 @@ std::string kaitai::kstream::bytes_to_str(const std::string src, int codepage) {
     // Calculate the length of the UTF-8 string
     int utf8_len = WideCharToMultiByte(CP_UTF8, 0, &utf16[0], utf16_len, 0, 0, 0, 0);
     if (utf8_len == 0) {
-        throw std::bytes_to_str_error("WideCharToMultiByte length calculation error");
+        throw bytes_to_str_error("WideCharToMultiByte length calculation error");
     }
 
     // Convert to UTF-8 string
     std::string utf8(utf8_len, '\0');
     if (WideCharToMultiByte(CP_UTF8, 0, &utf16[0], utf16_len, &utf8[0], utf8_len, 0, 0) == 0) {
-        throw std::bytes_to_str_error("WideCharToMultiByte conversion error");
+        throw bytes_to_str_error("WideCharToMultiByte conversion error");
     }
 
     return utf8;

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -239,7 +239,7 @@ TEST(KaitaiStreamTest, bytes_to_str_big_dest)
 {
     // Prepare a string in IBM437 that is reasonably big, fill it with U+2248 ALMOST EQUAL TO character,
     // which is just 1 byte 0xFB in IBM437.
-    const int len = 10'000'000;
+    const int len = 10000000;
     std::string src(len, '\xF7');
 
     std::string res = kaitai::kstream::bytes_to_str(src, "IBM437");

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -264,9 +264,7 @@ TEST(KaitaiStreamTest, bytes_to_str_invalid_seq)
         std::string res = kaitai::kstream::bytes_to_str("\x93\x97", "GB2312");
         FAIL() << "Expected illegal_seq_in_encoding exception";
     } catch (const kaitai::illegal_seq_in_encoding& e) {
-#ifdef KS_STR_ENCODING_ICONV
         EXPECT_EQ(e.what(), std::string("bytes_to_str error: illegal sequence: no info"));
-#endif
     }
 }
 #endif


### PR DESCRIPTION
This sets up a three new C++ exceptions related to surfacing encoding issues in a better, more structured way than a generic `std::runtime_error` we've been throwing so far:

* bytes_to_str_error: generic encoding problem
* unknown_encoding: problem related to unknown encoding being chosen an runtime
* illegal_seq_in_encoding: problem related to encoding engine being unable to perform encoding due to invalid sequence encountered in the input bytes

Added implementations and more detailed exceptions throwing/checking for both ICONV and WIN32API implementations.