### PR TITLE
Use targets in CMake instead of variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,11 @@
-cmake_minimum_required (VERSION 3.3)
+cmake_minimum_required (VERSION 3.11)
 project (kaitai_struct_cpp_stl_runtime CXX)
 enable_testing()
 
 set (CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(ZLIB)
-
-find_path(ICONV_INCLUDE_DIRS iconv.h)
-mark_as_advanced(ICONV_INCLUDE_DIRS)
-find_library(ICONV_LIBRARIES NAMES libiconv libiconv-2 iconv)
-mark_as_advanced(ICONV_LIBRARIES)
-
-set(ICONV_FOUND FALSE)
-if(ICONV_INCLUDE_DIRS AND ICONV_LIBRARIES)
-    SET(ICONV_FOUND TRUE)
-endif()
+find_package(Iconv)
 
 set (HEADERS
     kaitai/kaitaistream.h
@@ -34,14 +25,12 @@ add_library (${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
 set_property(TARGET ${PROJECT_NAME} PROPERTY PUBLIC_HEADER ${HEADERS})
 
 if (ZLIB_FOUND)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${ZLIB_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${ZLIB_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_ZLIB)
 endif()
 
-if(ICONV_FOUND)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${ICONV_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${ICONV_LIBRARIES})
+if(Iconv_FOUND)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Iconv::Iconv)
 endif()
 
 include(Common.cmake)


### PR DESCRIPTION
This PR replaces manual searching for Iconv with a find_package because there is [a find module for Iconv in CMake](https://cmake.org/cmake/help/latest/module/FindIconv.html) which is available since version 3.11. It is not merely a step towards modernization, it allows to cross-build this library when using Android NDK. This PR also sets 3.11 as minimum required version of CMake which is a rather reasonable because versions of CMake > 3.11 [are widely available in Linux distros](https://pkgs.org/download/cmake) (it goes without saying that you can also just download latest CMake version and install on any Linux distro). Zlib now is also linked as a target instead of using variables but this target [is available since CMake 3.1](https://cmake.org/cmake/help/latest/module/FindZLIB.html).