### PR TITLE
Add BUILD_TESTS CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project (kaitai_struct_cpp_stl_runtime CXX)
 enable_testing()
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+option(BUILD_TESTS "Build tests" ON)
 
 set (CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -46,4 +47,6 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 # Add the tests
-add_subdirectory(tests)
+if(BUILD_TESTS)
+    add_subdirectory(tests)
+endif()


### PR DESCRIPTION
# Context

- I am trying to update kaitai_struct_cpp_stl_runtime port in Vcpkg repository to the latest version, which supports creating a static library. 
- [PR in Vcpkg repository](https://github.com/microsoft/vcpkg/pull/34256).
 
# Current issue

- It seems like right now, for using the CMakeLists.txt file, it is mandatory to install GTest as well. Check [CMakeLists.txt](https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/blob/master/tests/CMakeLists.txt) which is included always.
- Given that at Vcpkg and even users may not be interested in building the tests (which forces having GTest), I suggest adding a CMake option for allowing to skip the build of tests.