### PR TITLE
remove template id from constructor/destructor

### DIFF
--- a/kaitai/exceptions.h
+++ b/kaitai/exceptions.h
@@ -115,7 +115,7 @@ protected:
 template<typename T>
 class validation_not_equal_error: public validation_failed_error {
 public:
-    validation_not_equal_error<T>(const T& expected, const T& actual, kstream* io, const std::string src_path):
+    validation_not_equal_error(const T& expected, const T& actual, kstream* io, const std::string src_path):
         validation_failed_error("not equal", io, src_path),
         m_expected(expected),
         m_actual(actual)
@@ -124,7 +124,7 @@ public:
 
     // "not equal, expected #{expected.inspect}, but got #{actual.inspect}"
 
-    virtual ~validation_not_equal_error<T>() KS_NOEXCEPT {};
+    virtual ~validation_not_equal_error() KS_NOEXCEPT {};
 
 protected:
     const T& m_expected;
@@ -138,7 +138,7 @@ protected:
 template<typename T>
 class validation_less_than_error: public validation_failed_error {
 public:
-    validation_less_than_error<T>(const T& min, const T& actual, kstream* io, const std::string src_path):
+    validation_less_than_error(const T& min, const T& actual, kstream* io, const std::string src_path):
         validation_failed_error("not in range", io, src_path),
         m_min(min),
         m_actual(actual)
@@ -147,7 +147,7 @@ public:
 
     // "not in range, min #{min.inspect}, but got #{actual.inspect}"
 
-    virtual ~validation_less_than_error<T>() KS_NOEXCEPT {};
+    virtual ~validation_less_than_error() KS_NOEXCEPT {};
 
 protected:
     const T& m_min;
@@ -161,7 +161,7 @@ protected:
 template<typename T>
 class validation_greater_than_error: public validation_failed_error {
 public:
-    validation_greater_than_error<T>(const T& max, const T& actual, kstream* io, const std::string src_path):
+    validation_greater_than_error(const T& max, const T& actual, kstream* io, const std::string src_path):
         validation_failed_error("not in range", io, src_path),
         m_max(max),
         m_actual(actual)
@@ -170,7 +170,7 @@ public:
 
     // "not in range, max #{max.inspect}, but got #{actual.inspect}"
 
-    virtual ~validation_greater_than_error<T>() KS_NOEXCEPT {};
+    virtual ~validation_greater_than_error() KS_NOEXCEPT {};
 
 protected:
     const T& m_max;
@@ -184,7 +184,7 @@ protected:
 template<typename T>
 class validation_not_any_of_error: public validation_failed_error {
 public:
-    validation_not_any_of_error<T>(const T& actual, kstream* io, const std::string src_path):
+    validation_not_any_of_error(const T& actual, kstream* io, const std::string src_path):
         validation_failed_error("not any of the list", io, src_path),
         m_actual(actual)
     {
@@ -192,7 +192,7 @@ public:
 
     // "not any of the list, got #{actual.inspect}"
 
-    virtual ~validation_not_any_of_error<T>() KS_NOEXCEPT {};
+    virtual ~validation_not_any_of_error() KS_NOEXCEPT {};
 
 protected:
     const T& m_actual;
@@ -205,7 +205,7 @@ protected:
 template<typename T>
 class validation_expr_error: public validation_failed_error {
 public:
-    validation_expr_error<T>(const T& actual, kstream* io, const std::string src_path):
+    validation_expr_error(const T& actual, kstream* io, const std::string src_path):
         validation_failed_error("not matching the expression", io, src_path),
         m_actual(actual)
     {
@@ -213,7 +213,7 @@ public:
 
     // "not matching the expression, got #{actual.inspect}"
 
-    virtual ~validation_expr_error<T>() KS_NOEXCEPT {};
+    virtual ~validation_expr_error() KS_NOEXCEPT {};
 
 protected:
     const T& m_actual;


### PR DESCRIPTION
In 0.10.1, I met compilation errors on gcc 13:
```
In file included from kaitai/kaitaistream.cpp:2:
kaitai/exceptions.h:118:35: error: expected unqualified-id before ‘const’
  118 |     validation_not_equal_error<T>(const T& expected, const T& actual, kstream* io, const std::string src_path):
      |                                   ^~~~~
kaitai/exceptions.h:118:35: error: expected ‘)’ before ‘const’
  118 |     validation_not_equal_error<T>(const T& expected, const T& actual, kstream* io, const std::string src_path):
      |                                  ~^~~~~
      |                                   )
kaitai/exceptions.h:127:13: error: template-id not allowed for destructor
  127 |     virtual ~validation_not_equal_error<T>() KS_NOEXCEPT {};
      |             ^
...
```

They are caused by `<T>` in constructor/destructor.
I want to remove it.

I confirmed gcc/clang/MSVC work fine after deleteing `<T>`.
