### PR TITLE
Fix unapplied CMake property `add_compile_options`

### DIFF
--- a/Common.cmake
+++ b/Common.cmake
@@ -9,8 +9,9 @@ else()
 endif()
 
 # Maximum warnings emission, treat all warnings as errors
-if (MSVC)
-    add_compile_options(/W4 /WX)
-else()
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
+#
+# This method was taken from https://www.pragmaticlinux.com/2022/07/enable-compiler-warnings-with-cmake/
+target_compile_options(${PROJECT_NAME} PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)


### PR DESCRIPTION
See https://stackoverflow.com/a/57637463/12940655:

> Command `add_compile_options` affects only on the targets, which are **created after** the command is invoked. Current command documentation says:
>
> > Adds options to the `COMPILE_OPTIONS` directory property.

> Because you call `add_library` before the `add_compile_options`, this library's options are not changed.

In our case, this meant that only the "unittest" project actually received these compilation options (ironically not due to the `include(../Common.cmake)` directive in /tests/CMakeLists.txt, but because of `include(Common.cmake)` preceding `add_subdirectory(tests)` in root /CMakeLists.txt), not the main `kaitai_struct_cpp_stl_runtime` project.

So this pull request replaces `add_compile_options` with `target_compile_options`, which works even when called after `add_library`. It also seems to be the recommended way to enable compiler warnings, see:

* https://discourse.cmake.org/t/compiler-options-for-warnings/9936/2
* https://www.foonathan.net/2018/10/cmake-warnings/#enabling-warnings-by-modifying-target-properties
* https://www.pragmaticlinux.com/2022/07/enable-compiler-warnings-with-cmake/

I used the `PRIVATE` keyword for both `target_compile_options` commands so that the warnings (and also the "treat warnings as errors" option `-Werror`) are only shown when we're building the runtime library in CI, not when someone uses the runtime library externally in their project. See also
https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1#dont-abuse-usage-requirements:

> ### Don't abuse usage requirements.
>
> As an example, don't add `-Wall` to the `PUBLIC` or `INTERFACE` section of `target_compile_options`, since it is not required to build depending targets.