### PR TITLE
Make each .cpp/.h file self-sufficient in `#include`s

### DIFF
--- a/.build/install-gtest
+++ b/.build/install-gtest
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -ef
+
+# Build GoogleTest from source and install it
+#
+# See https://github.com/google/googletest/blob/d83fee138a9ae6cb7c03688a2d08d4043a39815d/googletest/README.md#build-with-cmake
+
+gtest_version_tag=v1.14.0
+
+temp_dir=$(mktemp -d)
+function cleanup {
+	rm -rf -- "$temp_dir"
+}
+trap 'cleanup' EXIT
+
+# Download
+git clone --depth 1 -b "$gtest_version_tag" -- https://github.com/google/googletest.git "$temp_dir"
+cd -- "$temp_dir"
+mkdir build
+cd build
+# Configure - build only GoogleTest, not GoogleMock
+cmake .. -DBUILD_GMOCK=OFF
+# Build
+make
+# Install
+sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
         # NB: https://packages.ubuntu.com/jammy/iwyu apparently doesn't declare the `libclang-common-XXX-dev` package it
         # needs as a dependency (without it, `include-what-you-use` fails with "fatal error: 'stddef.h' file not found"
         # or similar), although this problem has been reported in 7 out of 7 bug reports at
-        # https://bugs.launchpad.net/ubuntu/+source/iwyu, the oldest one is from 2014.
+        # https://bugs.launchpad.net/ubuntu/+source/iwyu, the oldest being from 2014.
         #
-        # We intentionally specify an exact version of `iwyu` here, so that when a new version becomes available and we
-        # want to update to it, we'll have to change this hardcoded version manually and update the
-        # `libclang-common-XXX-dev` version accordingly (see
+        # Therefore, we deliberately require a fixed version of `iwyu` along with the compatible
+        # `libclang-common-XXX-dev` package. When a new version becomes available and we want to update to it, we'll
+        # have to change this hardcoded version manually and bump the `libclang-common-XXX-dev` version accordingly (see
         # https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md#clang-compatibility).
         run: |
           sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install GoogleTest
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtest-dev
+        run: .build/install-gtest
       - name: install include-what-you-use (iwyu)
         # NB: https://packages.ubuntu.com/jammy/iwyu apparently doesn't declare the `libclang-common-XXX-dev` package it
         # needs as a dependency (without it, `include-what-you-use` fails with "fatal error: 'stddef.h' file not found"
@@ -32,7 +30,9 @@ jobs:
         # want to update to it, we'll have to change this hardcoded version manually and update the
         # `libclang-common-XXX-dev` version accordingly (see
         # https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md#clang-compatibility).
-        run: sudo apt-get install -y iwyu=8.17-1 libclang-common-13-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iwyu=8.17-1 libclang-common-13-dev
       - name: build
         env:
           CPP_STANDARD: ${{ matrix.cpp-standard }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,28 @@ jobs:
           - '20'
     steps:
       - uses: actions/checkout@v4
-      - name: restore
+      - name: install GoogleTest
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtest-dev
+      - name: install include-what-you-use (iwyu)
+        # NB: https://packages.ubuntu.com/jammy/iwyu apparently doesn't declare the `libclang-common-XXX-dev` package it
+        # needs as a dependency (without it, `include-what-you-use` fails with "fatal error: 'stddef.h' file not found"
+        # or similar), although this problem has been reported in 7 out of 7 bug reports at
+        # https://bugs.launchpad.net/ubuntu/+source/iwyu, the oldest one is from 2014.
+        #
+        # We intentionally specify an exact version of `iwyu` here, so that when a new version becomes available and we
+        # want to update to it, we'll have to change this hardcoded version manually and update the
+        # `libclang-common-XXX-dev` version accordingly (see
+        # https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md#clang-compatibility).
+        run: sudo apt-get install -y iwyu=8.17-1 libclang-common-13-dev
       - name: build
         env:
           CPP_STANDARD: ${{ matrix.cpp-standard }}
-        run: .build/build -DCMAKE_CXX_STANDARD="$CPP_STANDARD" -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF
+        run: |
+          .build/build \
+            -DCMAKE_CXX_STANDARD="$CPP_STANDARD" -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF \
+            -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE='include-what-you-use;-Xiwyu;--verbose=3'
       - name: unittest
         run: .build/run-unittest
 

--- a/kaitai/exceptions.h
+++ b/kaitai/exceptions.h
@@ -3,8 +3,8 @@
 
 #include <kaitai/kaitaistream.h>
 
-#include <string>
-#include <stdexcept>
+#include <stdexcept> // std::runtime_error
+#include <string> // std::string
 
 // We need to use "noexcept" in virtual destructor of our exceptions
 // subclasses. Different compilers have different ideas on how to

--- a/kaitai/exceptions.h
+++ b/kaitai/exceptions.h
@@ -11,7 +11,7 @@
 // achieve that: C++98 compilers prefer `throw()`, C++11 and later
 // use `noexcept`. We define KS_NOEXCEPT macro for that.
 
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+#ifdef KAITAI_STREAM_H_CPP11_SUPPORT
 #define KS_NOEXCEPT noexcept
 #else
 #define KS_NOEXCEPT throw()

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -29,7 +29,7 @@
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
 #else
 // At this point it's either Linux or BSD. Both have "sys/param.h", so it's safe to include
-#include <sys/param.h>
+#include <sys/param.h> // `BSD` macro  // IWYU pragma: keep
 #if defined(BSD)
 // Supposed to work on FreeBSD: https://man.freebsd.org/cgi/man.cgi?query=bswap16&manpath=FreeBSD+14.0-RELEASE
 // Supposed to work on NetBSD: https://man.netbsd.org/NetBSD-10.0/bswap16.3

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -47,10 +47,18 @@
 #endif
 #endif
 
+#include <stdint.h> // int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t
+
+#include <algorithm> // std::reverse
+#include <cerrno> // errno, ERANGE
+#include <cstdlib> // std::strtoll
 #include <cstring> // std::memcpy
-#include <iostream>
-#include <vector>
-#include <stdexcept>
+#include <ios> // std::streamsize
+#include <istream> // std::istream
+#include <sstream> // std::stringstream, std::ostringstream
+#include <stdexcept> // std::runtime_error, std::invalid_argument, std::out_of_range
+#include <string> // std::string, std::getline
+#include <vector> // std::vector
 
 #ifdef KAITAI_STREAM_H_CPP11_SUPPORT
 #include <type_traits> // std::enable_if, std::is_trivially_copyable, std::is_trivially_constructible
@@ -156,9 +164,9 @@ uint64_t kaitai::kstream::pos() {
 }
 
 uint64_t kaitai::kstream::size() {
-    std::iostream::pos_type cur_pos = m_io->tellg();
-    m_io->seekg(0, std::ios::end);
-    std::iostream::pos_type len = m_io->tellg();
+    std::istream::pos_type cur_pos = m_io->tellg();
+    m_io->seekg(0, std::istream::end);
+    std::istream::pos_type len = m_io->tellg();
     m_io->seekg(cur_pos);
     return len;
 }
@@ -466,9 +474,9 @@ std::string kaitai::kstream::read_bytes(std::streamsize len) {
 }
 
 std::string kaitai::kstream::read_bytes_full() {
-    std::iostream::pos_type p1 = m_io->tellg();
-    m_io->seekg(0, std::ios::end);
-    std::iostream::pos_type p2 = m_io->tellg();
+    std::istream::pos_type p1 = m_io->tellg();
+    m_io->seekg(0, std::istream::end);
+    std::istream::pos_type p2 = m_io->tellg();
     size_t len = p2 - p1;
 
     // Note: this requires a std::string to be backed with a
@@ -638,7 +646,6 @@ int kaitai::kstream::mod(int a, int b) {
     return r;
 }
 
-#include <algorithm>
 void kaitai::kstream::unsigned_to_decimal(uint64_t number, char *buffer) {
     // Implementation from https://ideone.com/nrQfA8 by Alf P. Steinbach
     // (see https://www.zverovich.net/2013/09/07/integer-to-string-conversion-in-cplusplus.html#comment-1033931478)
@@ -659,7 +666,7 @@ int64_t kaitai::kstream::string_to_int(const std::string& str, int base) {
     char *str_end;
 
     errno = 0;
-    int64_t res = strtoll(str.c_str(), &str_end, base);
+    int64_t res = std::strtoll(str.c_str(), &str_end, base);
 
     // Check for successful conversion and throw an exception if the entire string was not converted
     if (str_end != str.c_str() + str.size()) {
@@ -712,10 +719,7 @@ uint8_t kaitai::kstream::byte_array_max(const std::string val) {
 #endif
 
 #ifdef KS_STR_ENCODING_ICONV
-
 #include <iconv.h>
-#include <cerrno>
-#include <stdexcept>
 
 std::string kaitai::kstream::bytes_to_str(const std::string src, const char *src_enc) {
     iconv_t cd = iconv_open(KS_STR_DEFAULT_ENCODING, src_enc);

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -51,6 +51,7 @@
 
 #include <algorithm> // std::reverse
 #include <cerrno> // errno, ERANGE
+#include <cstddef> // std::size_t
 #include <cstdlib> // std::strtoll
 #include <cstring> // std::memcpy
 #include <ios> // std::streamsize
@@ -477,7 +478,7 @@ std::string kaitai::kstream::read_bytes_full() {
     std::istream::pos_type p1 = m_io->tellg();
     m_io->seekg(0, std::istream::end);
     std::istream::pos_type p2 = m_io->tellg();
-    size_t len = p2 - p1;
+    std::size_t len = p2 - p1;
 
     // Note: this requires a std::string to be backed with a
     // contiguous buffer. Officially, it's a only requirement since
@@ -548,22 +549,22 @@ std::string kaitai::kstream::bytes_terminate(std::string src, char term, bool in
 // ========================================================================
 
 std::string kaitai::kstream::process_xor_one(std::string data, uint8_t key) {
-    size_t len = data.length();
+    std::size_t len = data.length();
     std::string result(len, ' ');
 
-    for (size_t i = 0; i < len; i++)
+    for (std::size_t i = 0; i < len; i++)
         result[i] = data[i] ^ key;
 
     return result;
 }
 
 std::string kaitai::kstream::process_xor_many(std::string data, std::string key) {
-    size_t len = data.length();
-    size_t kl = key.length();
+    std::size_t len = data.length();
+    std::size_t kl = key.length();
     std::string result(len, ' ');
 
-    size_t ki = 0;
-    for (size_t i = 0; i < len; i++) {
+    std::size_t ki = 0;
+    for (std::size_t i = 0; i < len; i++) {
         result[i] = data[i] ^ key[ki];
         ki++;
         if (ki >= kl)
@@ -574,10 +575,10 @@ std::string kaitai::kstream::process_xor_many(std::string data, std::string key)
 }
 
 std::string kaitai::kstream::process_rotate_left(std::string data, int amount) {
-    size_t len = data.length();
+    std::size_t len = data.length();
     std::string result(len, ' ');
 
-    for (size_t i = 0; i < len; i++) {
+    for (std::size_t i = 0; i < len; i++) {
         uint8_t bits = data[i];
         result[i] = (bits << amount) | (bits >> (8 - amount));
     }
@@ -732,13 +733,13 @@ std::string kaitai::kstream::bytes_to_str(const std::string src, const char *src
         }
     }
 
-    size_t src_len = src.length();
-    size_t src_left = src_len;
+    std::size_t src_len = src.length();
+    std::size_t src_left = src_len;
 
     // Start with a buffer length of double the source length.
-    size_t dst_len = src_len * 2;
+    std::size_t dst_len = src_len * 2;
     std::string dst(dst_len, ' ');
-    size_t dst_left = dst_len;
+    std::size_t dst_left = dst_len;
 
     // NB: this should be const char *, but for some reason iconv() requires non-const in its 2nd argument,
     // so we force it with a cast.
@@ -746,13 +747,13 @@ std::string kaitai::kstream::bytes_to_str(const std::string src, const char *src
     char *dst_ptr = &dst[0];
 
     while (true) {
-        size_t res = iconv(cd, &src_ptr, &src_left, &dst_ptr, &dst_left);
+        std::size_t res = iconv(cd, &src_ptr, &src_left, &dst_ptr, &dst_left);
 
-        if (res == (size_t)-1) {
+        if (res == (std::size_t)-1) {
             if (errno == E2BIG) {
                 // dst buffer is not enough to accomodate whole string
                 // enlarge the buffer and try again
-                size_t dst_used = dst_len - dst_left;
+                std::size_t dst_used = dst_len - dst_left;
                 dst_left += dst_len;
                 dst_len += dst_len;
                 dst.resize(dst_len);

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -50,13 +50,12 @@
 #include <stdint.h> // int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t
 
 #include <algorithm> // std::reverse
-#include <cerrno> // errno, ERANGE
-#include <cstddef> // std::size_t
-#include <cstdlib> // std::strtoll
+#include <cerrno> // errno, EINVAL, E2BIG, EILSEQ, ERANGE
+#include <cstdlib> // std::size_t, std::strtoll
 #include <cstring> // std::memcpy
 #include <ios> // std::streamsize
-#include <istream> // std::istream
-#include <sstream> // std::stringstream, std::ostringstream
+#include <istream> // std::istream  // IWYU pragma: keep
+#include <sstream> // std::stringstream, std::ostringstream  // IWYU pragma: keep
 #include <stdexcept> // std::runtime_error, std::invalid_argument, std::out_of_range
 #include <string> // std::string, std::getline
 #include <vector> // std::vector
@@ -588,6 +587,14 @@ std::string kaitai::kstream::process_rotate_left(std::string data, int amount) {
 
 #ifdef KS_ZLIB
 #include <zlib.h>
+
+// This instructs include-what-you-use not to suggest `#include <zconf.h>` just because it contains
+// the definition of `Bytef`. It seems `<zconf.h>` is not a header for public use or at least it's
+// not considered necessary to include it on top of `<zlib.h>`, because official usage examples that
+// use `Bytef` only include `<zlib.h>`, see
+// https://github.com/madler/zlib/blob/0f51fb4933fc9ce18199cb2554dacea8033e7fd3/test/example.c#L71
+//
+// IWYU pragma: no_include <zconf.h>
 
 std::string kaitai::kstream::process_zlib(std::string data) {
     int ret;

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -9,13 +9,14 @@
 #define KAITAI_STREAM_H_CPP11_SUPPORT
 #endif
 
-#include <istream>
-#include <sstream>
-#include <stdint.h>
-#include <sys/types.h>
-#include <limits>
-#include <stdexcept>
-#include <errno.h>
+#include <stdint.h> // int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t
+
+#include <ios> // std::streamsize
+#include <istream> // std::istream
+#include <limits> // std::numeric_limits
+#include <sstream> // std::istringstream
+#include <string> // std::string
+#include <type_traits> // std::enable_if, std::is_integral
 
 namespace kaitai {
 

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -16,7 +16,10 @@
 #include <limits> // std::numeric_limits
 #include <sstream> // std::istringstream
 #include <string> // std::string
+
+#ifdef KAITAI_STREAM_H_CPP11_SUPPORT
 #include <type_traits> // std::enable_if, std::is_integral
+#endif
 
 namespace kaitai {
 
@@ -234,8 +237,7 @@ public:
      * since C++11) in older C++ implementations.
      */
     template<typename I>
-// check for C++11 support - https://stackoverflow.com/a/40512515
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+#ifdef KAITAI_STREAM_H_CPP11_SUPPORT
     // https://stackoverflow.com/a/27913885
     typename std::enable_if<
             std::is_integral<I>::value &&

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -11,10 +11,9 @@
 
 #include <stdint.h> // int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t
 
-#include <ios> // std::streamsize
-#include <istream> // std::istream
+#include <ios> // std::streamsize, forward declaration of std::istream  // IWYU pragma: keep
 #include <limits> // std::numeric_limits
-#include <sstream> // std::istringstream
+#include <sstream> // std::istringstream  // IWYU pragma: keep
 #include <string> // std::string
 
 #ifdef KAITAI_STREAM_H_CPP11_SUPPORT

--- a/tests/gtest-nano.h
+++ b/tests/gtest-nano.h
@@ -1,9 +1,9 @@
 // gtest-nano.h implements very minimalistic GTest-compatible API that can be used to run tests in older
 // (C++98-compatible) environments.
 
+#include <cmath>
 #include <iostream>
 #include <vector>
-#include <math.h>
 
 namespace testing {
     struct TestInfo {
@@ -72,7 +72,7 @@ namespace testing {
 // Floating point comparison macro
 #define EXPECT_FLOAT_EQ(a, b)                     \
     do {                                          \
-        if (fabs(a - b) < 1e-6) {                 \
+        if (std::fabs(a - b) < 1e-6) {            \
         } else {                                  \
             ::testing::g_testPass = false;        \
         }                                         \

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -6,7 +6,13 @@
 
 #include "kaitai/kaitaistream.h"
 #include "kaitai/exceptions.h"
-#include <sstream>
+
+#include <stdint.h> // int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t
+
+#include <limits> // std::numeric_limits
+#include <sstream> // std::istringstream
+#include <stdexcept> // std::out_of_range, std::invalid_argument
+#include <string> // std::string
 
 #define SETUP_STREAM(...)                                                                  \
     const uint8_t input_bytes[] = { __VA_ARGS__ };                                         \

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1,7 +1,7 @@
 #ifdef GTEST_NANO
 #include "tests/gtest-nano.h"
 #else
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 #endif
 
 #include "kaitai/kaitaistream.h"


### PR DESCRIPTION
Until now, some parts of the code used symbols from the standard library without including the corresponding standard library header using `#include` to ensure that the symbol is defined. That is, they silently assumed that the header has been already included by "someone else".

These assumptions were sometimes met in our code due to transitive inclusions. For example, the missing `#include <stdexcept>` in `tests/unittest.cpp` would not turn into a compile error, because `tests/unittest.cpp` included `kaitai/exceptions.h`, which contains `#include <stdexcept>`. However, it is discouraged to rely on transitive inclusions, see https://google.github.io/styleguide/cppguide.html#Include_What_You_Use:

> Do not rely on transitive inclusions. This allows people to remove no-longer-needed `#include` statements from their headers without breaking clients. This also applies to related headers - `foo.cc` should include `bar.h` if it uses a symbol from it even if `foo.h` includes `bar.h`.

Instances of this problem in our code aren't limited to "maintainability issues" - they can also reduce portability. For instance, @roelschroeven apparently ran into a `strtoll not found` error in our `kaitai/kaitaistream.cpp` source file that he had to patch like this (see https://github.com/roelschroeven/kaitai_struct_cpp_stl_runtime/commit/db668fad3f14b95251061c7c4793d60d2d1fadd5):

```diff
diff --git a/kaitai/kaitaistream.cpp b/kaitai/kaitaistream.cpp
index a3810ab..4d5ded2 100644
--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <vector>
 #include <stdexcept>
+#include <cstdlib>

 // ========================================================================
 // Integer from raw data with correct endianness
@@ -585,7 +586,7 @@ int64_t kaitai::kstream::string_to_int(const std::string& str, int base) {
     char *str_end;

     errno = 0;
-    int64_t res = strtoll(str.c_str(), &str_end, base);
+    int64_t res = std::strtoll(str.c_str(), &str_end, base);

     // Check for successful conversion and throw an exception if the entire string was not converted
     if (str_end != str.c_str() + str.size()) {
```

This makes sense according to https://en.cppreference.com/w/cpp/string/byte/strtol - we shouldn't assume that `std::strtoll` exists when we don't have `#include <cstdlib>` anywhere in our code. It worked fine without it in CI and on my local gcc 12.3.0 only because some standard library header that we include happened to use `<cstdlib>` as part of its implementation. For curiosity, I used this command locally to dump a tree that shows why each header was `#include`d:

```
c++ -DKS_STR_ENCODING_ICONV -DKS_ZLIB -I. -std=c++11 -H -MM ./kaitai/kaitaistream.cpp 2> kaitaistream-deps.log
```

So for example, we can see that on the gcc 12.3, the `<algorithm>` header includes `<cstdlib>` for some reason, so that's one of the reasons there's no compile error if we forget `#include <cstdlib>` in `kaitaistream.cpp`:

```
. /usr/include/c++/12/algorithm
.. /usr/include/c++/12/bits/stl_algo.h
... /usr/include/c++/12/cstdlib
```

This is completely implementation-specific, of course. There's nothing in the C++ standard that requires `<algorithm>` to include `<cstdlib>`, and in other implementations this may not be the case at all.

See also https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf10-avoid-dependencies-on-implicitly-included-names