### PR TITLE
read_f{4,8}{be,le}(): fix violations of strict aliasing rules

### DIFF
--- a/Common.cmake
+++ b/Common.cmake
@@ -13,5 +13,14 @@ endif()
 # This method was taken from https://www.pragmaticlinux.com/2022/07/enable-compiler-warnings-with-cmake/
 target_compile_options(${PROJECT_NAME} PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:
+        -Wall -Wextra -Wpedantic -Werror
+        # See <https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstrict-aliasing_003dn>:
+        #
+        # > Level 1: (...) it has very few false negatives. However, it has many false positives.
+        #
+        # If we encounter into false positives in the future, we can increase the level, but let's
+        # start with the most aggressive option to make sure we don't miss anything.
+        -fstrict-aliasing -Wstrict-aliasing=1
+    >
 )

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -4,6 +4,11 @@
 // Kaitai Struct runtime API version: x.y.z = 'xxxyyyzzz' decimal
 #define KAITAI_STRUCT_VERSION 11000L
 
+// check for C++11 support - https://stackoverflow.com/a/40512515
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+#define KAITAI_STREAM_H_CPP11_SUPPORT
+#endif
+
 #include <istream>
 #include <sstream>
 #include <stdint.h>


### PR DESCRIPTION
Solves https://github.com/kismetwireless/kismet/issues/518