### PR TITLE
Support FreeBSD 14.0 + NetBSD 10.0 + add testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,9 @@ jobs:
             .build/run-unittest
   netbsd_10_0:
     runs-on: ubuntu-latest
+    # Doesn't use clang, has gcc:
+    # c++ (nb3 20231008) 10.5.0
+    # Copyright (C) 2020 Free Software Foundation, Inc.
     steps:
       - uses: actions/checkout@v4
       - name: Run in NetBSD
@@ -134,8 +137,6 @@ jobs:
             env
             c++ --version
             gcc --version
-            clang++ --version
-            pkg info
 
             echo '#### Building'
             .build/build -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,11 +99,10 @@ jobs:
           release: "14.0"
           usesh: true
           prepare: |
-            pkg install -y curl
+            pkg install -y cmake
 
           run: |
-            pwd
-            ls -lah
+            echo '#### System information'
             whoami
             env
             freebsd-version
@@ -111,3 +110,9 @@ jobs:
             gcc --version
             clang++ --version
             pkg info
+
+            echo '#### Building'
+            .build/build -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF
+
+            echo '#### Testing'
+            .build/run-unittest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,3 +89,25 @@ jobs:
         run: .build\build.ps1 -GTestPath C:\vcpkg\installed\x64-windows
       - name: unittest
         run: .build\run-unittest.ps1
+  freebsd_14_0:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run in FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "14.0"
+          usesh: true
+          prepare: |
+            pkg install -y curl
+
+          run: |
+            pwd
+            ls -lah
+            whoami
+            env
+            freebsd-version
+            c++ --version
+            gcc --version
+            clang++ --version
+            pkg info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           release: "14.0"
           usesh: true
           prepare: |
-            pkg install -y cmake
+            pkg install -y cmake googletest
 
           run: |
             echo '#### System information'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,3 +116,29 @@ jobs:
 
             echo '#### Testing'
             .build/run-unittest
+  netbsd_10_0:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run in NetBSD
+        uses: vmactions/netbsd-vm@v1
+        with:
+          release: "10.0"
+          usesh: true
+          prepare: |
+            /usr/sbin/pkg_add cmake googletest
+
+          run: |
+            echo '#### System information'
+            whoami
+            env
+            c++ --version
+            gcc --version
+            clang++ --version
+            pkg info
+
+            echo '#### Building'
+            .build/build -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF
+
+            echo '#### Testing'
+            .build/run-unittest

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -38,6 +38,9 @@
 #define bswap_16(x) bswap16(x)
 #define bswap_32(x) bswap32(x)
 #define bswap_64(x) bswap64(x)
+#define __BYTE_ORDER    BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
 #else // !__APPLE__ or !_MSC_VER or !__QNX__ or !BSD
 #include <endian.h>
 #include <byteswap.h>

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -27,7 +27,10 @@
 #define __BYTE_ORDER    BYTE_ORDER
 #define __BIG_ENDIAN    BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
-#elif defined(BSD)
+#else
+// At this point it's either Linux or BSD. Both have "sys/param.h", so it's safe to include
+#include <sys/param.h>
+#if defined(BSD)
 // Supposed to work on FreeBSD: https://man.freebsd.org/cgi/man.cgi?query=bswap16&manpath=FreeBSD+14.0-RELEASE
 // Supposed to work on NetBSD: https://man.netbsd.org/NetBSD-10.0/bswap16.3
 #include <sys/endian.h>
@@ -38,6 +41,7 @@
 #else // !__APPLE__ or !_MSC_VER or !__QNX__ or !BSD
 #include <endian.h>
 #include <byteswap.h>
+#endif
 #endif
 
 #include <cstring> // std::memcpy

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -27,7 +27,15 @@
 #define __BYTE_ORDER    BYTE_ORDER
 #define __BIG_ENDIAN    BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
-#else // !__APPLE__ or !_MSC_VER or !__QNX__
+#elif defined(BSD)
+// Supposed to work on FreeBSD: https://man.freebsd.org/cgi/man.cgi?query=bswap16&manpath=FreeBSD+14.0-RELEASE
+// Supposed to work on NetBSD: https://man.netbsd.org/NetBSD-10.0/bswap16.3
+#include <sys/endian.h>
+#include <sys/types.h>
+#define bswap_16(x) bswap16(x)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+#else // !__APPLE__ or !_MSC_VER or !__QNX__ or !BSD
 #include <endian.h>
 #include <byteswap.h>
 #endif

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -4,7 +4,10 @@
 #include <gtest/gtest.h>
 #endif
 
+// Necessary for proper detection of *BSD
+#if !defined(_MSC_VER)
 #include <sys/param.h>
+#endif
 
 #include "kaitai/kaitaistream.h"
 #include "kaitai/exceptions.h"

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -4,6 +4,8 @@
 #include <gtest/gtest.h>
 #endif
 
+#include <sys/param.h>
+
 #include "kaitai/kaitaistream.h"
 #include "kaitai/exceptions.h"
 #include <sstream>
@@ -359,7 +361,6 @@ TEST(KaitaiStreamTest, bytes_to_str_invalid_seq_euc_jp_too_short)
     }
 }
 
-
 TEST(KaitaiStreamTest, bytes_to_str_invalid_seq_gb2312_too_short)
 {
     try {
@@ -376,8 +377,12 @@ TEST(KaitaiStreamTest, bytes_to_str_invalid_seq_gb2312_too_short)
     }
 }
 
+#if !defined(__FreeBSD__) && !defined(__NetBSD__)
 TEST(KaitaiStreamTest, bytes_to_str_invalid_seq_gb2312_two_bytes)
 {
+    // 0xB0 0x30 is illegal sequence in GB2312: 0xB0 must be followed by [0xA1..0xFE].
+    // However, some iconv engines, namely CITRUS integrated with modern FreeBSD (10+) and NetBSD,
+    // are not considering this as error and thus not returning EILSEQ.
     try {
         std::string res = kaitai::kstream::bytes_to_str("\xb0\x30", "GB2312");
         FAIL() << "Expected illegal_seq_in_encoding exception";
@@ -391,6 +396,7 @@ TEST(KaitaiStreamTest, bytes_to_str_invalid_seq_gb2312_two_bytes)
 #endif
     }
 }
+#endif
 
 TEST(KaitaiStreamTest, bytes_to_str_invalid_seq_utf_16le_odd_bytes)
 {


### PR DESCRIPTION
Adds proven support for FreeBSD and NetBSD. Uses GH Actions for 2 new workflows (which internally download an image for a VM and runs it in qemu emulator on Ubuntu host).