### PR TITLE
Make KS_ZLIB flag public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE ${PROJECT_SOURCE_DIR})
 
 if (ZLIB_FOUND)
     target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE -DKS_ZLIB)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC -DKS_ZLIB)
 endif()
 
 if(Iconv_FOUND)


### PR DESCRIPTION
When using the runtime with zlib support with cmake, the required KS_ZLIB flags is not propagated to the linking target.