### PR TITLE
Fix FreeBSD build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,9 +146,9 @@ jobs:
             whoami
             env
             freebsd-version
-            c++ --version
-            gcc --version
-            clang++ --version
+            c++ --version || :
+            gcc --version || :
+            clang++ --version || :
             pkg info
 
             echo '#### Installing GoogleTest'


### PR DESCRIPTION
Something has changed in how GH Action runs FreeBSD builds. Looks like `gcc --version` with no gcc available now breaks the build of error.

This mitigates the problem.