### PR TITLE
.build/*.ps1: require PowerShell 7.4+ for easier error handling

### DIFF
--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -1,8 +1,14 @@
+# This script requires at least PowerShell 7.4 to run, as it relies on support
+# for the `$PSNativeCommandUseErrorActionPreference` variable for proper error
+# handling.
+#Requires -Version 7.4
+
 <#
 .DESCRIPTION
 Builds Kaitai Struct C++ runtime library and unit tests
 
 Requires:
+- PowerShell 7.4 or later
 - MSVC native tools installed and available in the command prompt
 - cmake/ctest available (normally installed with MSVC native tools)
 - GTest installed, path passed in `-GTestPath`
@@ -24,6 +30,8 @@ param (
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+# Treat non-zero exit codes from native commands as standard PowerShell errors.
+$PSNativeCommandUseErrorActionPreference = $true
 
 # Go to repo root
 $repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
@@ -34,17 +42,8 @@ try {
     cd build
 
     $env:VERBOSE = '1'
-
     cmake -DCMAKE_PREFIX_PATH="$GTestPath" -DSTRING_ENCODING_TYPE="$EncodingType" .. @ExtraArgs
-    if ($LastExitCode -ne 0) {
-        throw "'cmake' exited with code $LastExitCode"
-    }
-
     cmake --build . --config Debug
-    if ($LastExitCode -ne 0) {
-        throw "'cmake --build' exited with code $LastExitCode"
-    }
-
     cp $GTestPath\debug\bin\*.dll tests\Debug
     cp Debug\kaitai_struct_cpp_stl_runtime.dll tests\Debug
 } finally {

--- a/.build/run-unittest.ps1
+++ b/.build/run-unittest.ps1
@@ -1,12 +1,21 @@
+# This script requires at least PowerShell 7.4 to run, as it relies on support
+# for the `$PSNativeCommandUseErrorActionPreference` variable for proper error
+# handling.
+#Requires -Version 7.4
+
 <#
 .DESCRIPTION
 Runs unit tests on Windows
+
+Requires PowerShell 7.4 or later.
 #>
 
 # Standard boilerplate
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+# Treat non-zero exit codes from native commands as standard PowerShell errors.
+$PSNativeCommandUseErrorActionPreference = $true
 
 # Go to repo root
 $repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
@@ -24,7 +33,7 @@ try {
     # passed to the script (see https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.5#args).
     # We use [splatting](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-7.5)
     # to pass all received arguments to the test runner.
-    ./tests/Debug/unittest.exe @args
+    .\tests\Debug\unittest.exe @args
 } finally {
     Pop-Location
 }


### PR DESCRIPTION
Setting the `$PSNativeCommandUseErrorActionPreference` to `$true` ensures that native commands (typically `.exe` files) with a non-zero exit code are automatically treated as an error. This aligns error handling in PowerShell scripts with that in corresponding shell scripts: if an external command called from a script fails, the script terminates.

`$PSNativeCommandUseErrorActionPreference` was introduced as a stable feature in PowerShell 7.4, see
<https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_error_handling?view=powershell-7.6#external-program-errors>:

> PowerShell 7.3 added the experimental preference variable `$PSNativeCommandUseErrorActionPreference`, which became a stable feature in 7.4. When you set this variable to `$true`, it causes a non-zero exit code to emit a **non-terminating error** whose message states the specific exit code (a `NativeCommandExitException`). This error respects `$ErrorActionPreference`, so setting it to `Stop` promotes the error to a script-terminating error that can be caught with `try`/`catch`.

Therefore, we also add a `#Requires -Version 7.4` statement to both scripts to prevent them from running on older versions of PowerShell that don't support this feature.

---

This change follows up on 01fafdd87868612cbb8b53a17d46eb44224caaa2. In that commit, I added explicit error handling for `cmake` invocations in the form of `if ($LastExitCode -ne 0) { throw ... }`. It works well; the only problem is that it's very easy to forget to do this.

Proof of this is a recent failure of the `windows` job in CI, which looked like this:

```
Run .build\run-unittest.ps1
  .build\run-unittest.ps1
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
Error: Process completed with exit code 1.
```

As you can see, we received a very cryptic error that doesn't provide any information about the cause. This is a direct result of the fact that the `.build\run-unittest.ps1` script does not explicitly check the exit code of the `.\tests\Debug\unittest.exe` executable.

In contrast, here's how the same failure is now reported after adding `$PSNativeCommandUseErrorActionPreference = $true`:

```
PS C:\temp\kaitai_struct\runtime\cpp_stl> .build\run-unittest.ps1
NativeCommandExitException: C:\temp\kaitai_struct\runtime\cpp_stl\.build\run-unittest.ps1:37
Line |
  37 |      .\tests\Debug\unittest.exe @args
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Program "unittest.exe" ended with non-zero exit code: -1073741515 (0xC0000135).
```

This clearly indicates what the problem is: the exit code `0xC0000135` corresponds to the identifier `STATUS_DLL_NOT_FOUND`, so we at least know that the `unittest.exe` binary cannot be run because of a missing .dll dependency. It doesn't tell us *which* .dll is missing, but that's just how Windows works :)