### PR TITLE
GHA: bump to macOS 26 (was 15)

### DIFF
--- a/.build/gtest-v1.17.0-fix-Werror-character-conversion.patch
+++ b/.build/gtest-v1.17.0-fix-Werror-character-conversion.patch
@@ -1,0 +1,22 @@
+diff --git a/googletest/include/gtest/gtest-printers.h b/googletest/include/gtest/gtest-printers.h
+index 198a7693..bbb0fa7e 100644
+--- a/googletest/include/gtest/gtest-printers.h
++++ b/googletest/include/gtest/gtest-printers.h
+@@ -521,11 +521,15 @@ GTEST_API_ void PrintTo(wchar_t wc, ::std::ostream* os);
+ 
+ GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
+ inline void PrintTo(char16_t c, ::std::ostream* os) {
+-  PrintTo(ImplicitCast_<char32_t>(c), os);
++  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
++  // Also see https://github.com/google/googletest/issues/4762.
++  PrintTo(static_cast<char32_t>(c), os);
+ }
+ #ifdef __cpp_lib_char8_t
+ inline void PrintTo(char8_t c, ::std::ostream* os) {
+-  PrintTo(ImplicitCast_<char32_t>(c), os);
++  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
++  // Also see https://github.com/google/googletest/issues/4762.
++  PrintTo(static_cast<char32_t>(c), os);
+ }
+ #endif
+ 

--- a/.build/gtest-v1.8.1-fix-Werror-maybe-uninitialized.patch
+++ b/.build/gtest-v1.8.1-fix-Werror-maybe-uninitialized.patch
@@ -1,5 +1,5 @@
 diff --git a/googletest/src/gtest-death-test.cc b/googletest/src/gtest-death-test.cc
-index 0908355..d6f492e 100644
+index 09083551..d6f492e3 100644
 --- a/googletest/src/gtest-death-test.cc
 +++ b/googletest/src/gtest-death-test.cc
 @@ -1212,14 +1212,14 @@ static int ExecDeathTestChildMain(void* child_arg) {
@@ -10,7 +10,7 @@ index 0908355..d6f492e 100644
 +  int dummy = 0;
    *result = (&dummy < ptr);
  }
-
+ 
  // Make sure AddressSanitizer does not tamper with the stack here.
  GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
  static bool StackGrowsDown() {

--- a/.build/install-gtest
+++ b/.build/install-gtest
@@ -70,9 +70,17 @@ trap 'cleanup' INT TERM HUP EXIT
 git clone --depth 1 -b "$gtest_version_tag" -- https://github.com/google/googletest.git "$temp_dir"
 cd -- "$temp_dir"
 if [ "$gtest_version_tag" = release-1.8.1 ]; then
-	# We must apply a patch to fix `-Werror=maybe-uninitialized` (see
-	# https://github.com/google/googletest/issues/3219), otherwise it won't compile
+	# We must apply
+	# https://github.com/google/googletest/commit/4679637f1c9d5a0728bdc347a531737fad0b1ca3
+	# as a patch to fix `-Werror=maybe-uninitialized`, otherwise it won't
+	# compile (see https://github.com/google/googletest/issues/3219)
 	git apply -- "$script_dir"/gtest-v1.8.1-fix-Werror-maybe-uninitialized.patch
+elif [ "$gtest_version_tag" = v1.17.0 ]; then
+	# We must apply
+	# https://github.com/google/googletest/commit/fa8438ae6b70c57010177de47a9f13d7041a6328
+	# as a patch to fix `[-Werror,-Wcharacter-conversion]`, otherwise it won't
+	# compile with Clang 21+ (see https://github.com/google/googletest/issues/4948)
+	git apply -- "$script_dir"/gtest-v1.17.0-fix-Werror-character-conversion.patch
 fi
 mkdir build
 cd build

--- a/.build/install-gtest
+++ b/.build/install-gtest
@@ -29,20 +29,25 @@ fi
 
 case $cpp_standard in
 	98)
-		# GoogleTest v1.8.1 seems to be the last version supporting C++98,
+		# GoogleTest v1.8.1 is the last version supporting C++98,
 		# see https://github.com/google/googletest/releases/tag/release-1.8.1
 		gtest_version_tag=release-1.8.1
 		;;
 	11)
-		# GoogleTest v1.12.1 seems to be the last version supporting C++11,
+		# GoogleTest v1.12.1 is the last version supporting C++11,
 		# see https://github.com/google/googletest/releases/tag/release-1.12.1
 		gtest_version_tag=release-1.12.1
 		;;
+	14)
+		# GoogleTest v1.16.0 is the last version supporting C++14,
+		# see https://github.com/google/googletest/releases/tag/v1.16.0
+		gtest_version_tag=v1.16.0
+		;;
 	*)
-		if [ "$cpp_standard" -ge 14 ] && [ "$cpp_standard" -le 26 ]; then
-			# GoogleTest v1.16.0 (the latest version at the time of writing) requires at
-			# least C++14, see https://github.com/google/googletest/releases/tag/v1.16.0
-			gtest_version_tag=v1.16.0
+		if [ "$cpp_standard" -ge 17 ] && [ "$cpp_standard" -le 26 ]; then
+			# GoogleTest v1.17.0 (the latest version at the time of writing) requires at
+			# least C++17, see https://github.com/google/googletest/releases/tag/v1.17.0
+			gtest_version_tag=v1.17.0
 		else
 			die "Error: unsupported value $1 of <cpp-standard>"
 		fi

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,10 @@ indent_style = space
 [*.ps1]
 indent_size = 4
 
+# In .patch files, trailing whitespace is significant
+[*.patch]
+trim_trailing_whitespace = false
+
 [*.yml]
 indent_size = 2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run tests
         run: .build/run-unittest --valgrind
   macos:
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
BTW, `macos-latest` is currently still an alias of `macos-15`, but it will soon become `macos-26`: https://github.com/actions/runner-images/issues/14167

This means that `macos-26` should be stable enough for us to switch to.