### PR TITLE
GHA: run FreeBSD VM using cross-platform-actions/action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,36 +145,36 @@ jobs:
         run: .build\run-unittest.ps1
   freebsd:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: cpa.sh {0}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - name: Run in FreeBSD
-        uses: vmactions/freebsd-vm@d1e65811565151536c0c894fff74f06351ed26e6 # v1.4.5
+      - name: Start VM
+        uses: cross-platform-actions/action@be3d7e9ff5c8770b9c51b1a8c8c5446e1cad7cf9 # v1.2.0
         with:
-          release: "14.3"
-          usesh: true
-          prepare: |
-            pkg install -y git cmake
-
-          run: |
-            echo '#### System information'
-            whoami
-            env
-            freebsd-version
-            c++ --version || :
-            gcc --version || :
-            clang++ --version || :
-            pkg info
-
-            echo '#### Installing GoogleTest'
-            .build/install-gtest 11
-
-            echo '#### Building'
-            .build/build -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF
-
-            echo '#### Testing'
-            .build/run-unittest
+          operating_system: freebsd
+          version: '14.3'
+      - name: Print system information
+        run: |
+          set -x
+          uname -a
+          echo "$SHELL"
+          pwd
+          ls -la
+          whoami
+          env | sort
+          c++ --version
+      - name: Install packages
+        run: sudo pkg install -y git cmake
+      - name: Install GoogleTest
+        run: .build/install-gtest 11
+      - name: Build
+        run: .build/build -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF
+      - name: Run tests
+        run: .build/run-unittest
   netbsd:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
Since https://github.com/cross-platform-actions/action/releases/tag/v1.1.0, `cross-platform-actions/action` allows (and encourages) using multiple steps, making CI run logs look more consistent with those of other jobs.

In addition, dropping the https://github.com/vmactions/freebsd-vm action means one less dependency we have to worry about.

To me, https://github.com/cross-platform-actions/action also seems to be better maintained and the code is better organized. In our case, it's also consistently faster (~1 min 20 seconds vs 2+ minutes with `vmactions/freebsd-vm`).

Closes #93