### PR TITLE
GHA: bump to FreeBSD 15.1 (was 14.3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
         uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
           operating_system: freebsd
-          version: '14.3'
+          version: '15.1'
       - name: Print system information
         run: |
           set -x


### PR DESCRIPTION
Note: in https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/pull/98, we bumped to https://github.com/cross-platform-actions/action/releases/tag/v1.3.0, which added support for FreeBSD 15.1.